### PR TITLE
Add Docker containerization and GHCR CI push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,32 @@ jobs:
           DB_PASSWORD: ci-placeholder
           SPRING_PROFILES_ACTIVE: test
         run: mvn test
+
+  push-image:
+    name: Push Docker Image to GHCR
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./Project
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/campusconnect:latest
+            ghcr.io/${{ github.repository_owner }}/campusconnect:${{ github.sha }}

--- a/Project/.dockerignore
+++ b/Project/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.idea/
+.env
+*.iml
+*.log

--- a/Project/Dockerfile
+++ b/Project/Dockerfile
@@ -1,0 +1,28 @@
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM maven:3.9-eclipse-temurin-17 AS builder
+WORKDIR /app
+
+# Download dependencies first (cached layer — only re-runs if pom.xml changes)
+COPY pom.xml .
+RUN mvn dependency:go-offline -B -q
+
+COPY src ./src
+RUN mvn package -DskipTests -B -q
+
+# ── Stage 2: Run ─────────────────────────────────────────────────────────────
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+
+RUN addgroup -S campusconnect && adduser -S campusconnect -G campusconnect
+
+COPY --from=builder /app/target/*.jar app.jar
+
+RUN mkdir -p /uploads && chown campusconnect:campusconnect /uploads
+
+USER campusconnect
+
+EXPOSE 8080
+
+ENV UPLOAD_DIR=/uploads/
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Project/docker/init.sql
+++ b/Project/docker/init.sql
@@ -1,0 +1,183 @@
+-- Docker init script — runs automatically on first container startup.
+-- CREATE DATABASE and CREATE USER are handled by the MySQL image via env vars;
+-- this script only sets up the schema and seed data.
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT = @@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS = @@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION = @@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE = @@TIME_ZONE */;
+/*!40103 SET TIME_ZONE = '+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS = @@UNIQUE_CHECKS, UNIQUE_CHECKS = 0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS = @@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS = 0 */;
+/*!40101 SET @OLD_SQL_MODE = @@SQL_MODE, SQL_MODE = 'NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES = @@SQL_NOTES, SQL_NOTES = 0 */;
+
+-- Table structure for table `department`
+DROP TABLE IF EXISTS `department`;
+CREATE TABLE `department`
+(
+    `department_id`   INT         NOT NULL AUTO_INCREMENT,
+    `department_name` VARCHAR(50) NOT NULL,
+    PRIMARY KEY (`department_id`),
+    UNIQUE KEY `department_name` (`department_name`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1004
+  DEFAULT CHARSET = latin1;
+
+INSERT INTO `department`
+VALUES (1001, 'Computer Applications'),
+       (1002, 'Computer Science'),
+       (1003, 'Physics');
+
+-- Table structure for table `members`
+DROP TABLE IF EXISTS `members`;
+CREATE TABLE `members`
+(
+    `id`         INT          NOT NULL AUTO_INCREMENT,
+    `user_id`    VARCHAR(50)  NOT NULL,
+    `email`      VARCHAR(255) NOT NULL,
+    `pw`         CHAR(68)     NOT NULL,
+    `active`     TINYINT      NOT NULL,
+    `department` VARCHAR(100) NOT NULL,
+    `dept_id`    INT,
+    PRIMARY KEY (`user_id`),
+    UNIQUE KEY `id` (`id`),
+    UNIQUE KEY `email` (`email`),
+    FOREIGN KEY (`dept_id`) REFERENCES `department` (`department_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 8
+  DEFAULT CHARSET = latin1;
+
+INSERT INTO `members`
+VALUES (1, 'hod1', 'hod1@campus.com', '{noop}password', 1, 'Computer Applications', 1001),
+       (2, 'hod2', 'hod2@campus.com', '{noop}password', 1, 'Computer Science', 1002),
+       (3, 'teacher1', 'teacher1@campus.com', '{noop}password', 1, 'Computer Applications', 1001),
+       (4, 'teacher2', 'teacher2@campus.com', '{noop}password', 1, 'Physics', 1003),
+       (5, 'student1', 'student1@campus.com', '{noop}password', 1, 'Computer Science', 1002),
+       (6, 'student2', 'student2@campus.com', '{noop}password', 1, 'Physics', 1003),
+       (7, 'admin1', 'admin1@campus.com', '{noop}password', 1, 'Computer Applications', 1001),
+       (8, 'admin2', 'admin2@campus.com', '{noop}password', 1, 'Physics', 1003);
+
+-- Table structure for table `roles`
+DROP TABLE IF EXISTS `roles`;
+CREATE TABLE `roles`
+(
+    `user_id` VARCHAR(50) NOT NULL,
+    `role`    VARCHAR(50) NOT NULL,
+    PRIMARY KEY (`user_id`),
+    CONSTRAINT `fk_user_roles` FOREIGN KEY (`user_id`) REFERENCES `members` (`user_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+INSERT INTO `roles`
+VALUES ('hod1', 'ROLE_HOD'),
+       ('hod2', 'ROLE_HOD'),
+       ('teacher1', 'ROLE_TEACHER'),
+       ('teacher2', 'ROLE_TEACHER'),
+       ('student1', 'ROLE_STUDENT'),
+       ('student2', 'ROLE_STUDENT'),
+       ('admin1', 'ROLE_ADMIN'),
+       ('admin2', 'ROLE_ADMIN');
+
+-- Table structure for table `department_details`
+DROP TABLE IF EXISTS `department_details`;
+CREATE TABLE `department_details`
+(
+    `department_member_id` INT         NOT NULL AUTO_INCREMENT,
+    `department_id`        INT         NOT NULL,
+    `user_name`            VARCHAR(50) NOT NULL,
+    `role`                 VARCHAR(50) NOT NULL,
+    PRIMARY KEY (`department_member_id`),
+    UNIQUE KEY `user_name` (`user_name`),
+    KEY `department_id` (`department_id`),
+    CONSTRAINT `fk_department` FOREIGN KEY (`department_id`) REFERENCES `department` (`department_id`),
+    CONSTRAINT `fk_member` FOREIGN KEY (`user_name`) REFERENCES `members` (`user_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10
+  DEFAULT CHARSET = latin1;
+
+INSERT INTO `department_details`
+VALUES (1, 1001, 'hod1', 'HOD'),
+       (2, 1002, 'hod2', 'HOD'),
+       (3, 1001, 'teacher1', 'TEACHER'),
+       (4, 1003, 'teacher2', 'TEACHER'),
+       (5, 1002, 'student1', 'STUDENT'),
+       (6, 1003, 'student2', 'STUDENT'),
+       (7, 1001, 'admin1', 'ADMIN'),
+       (8, 1003, 'admin2', 'ADMIN');
+
+-- Table structure for table `course_details`
+DROP TABLE IF EXISTS `course_details`;
+CREATE TABLE IF NOT EXISTS `course_details`
+(
+    `course_id`     INT          NOT NULL AUTO_INCREMENT,
+    `course_name`   VARCHAR(100) NOT NULL,
+    `department_id` INT          NOT NULL,
+    PRIMARY KEY (`course_id`),
+    CONSTRAINT `fk_department_course` FOREIGN KEY (`department_id`) REFERENCES `department` (`department_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = latin1;
+
+-- Table structure for table `semester`
+DROP TABLE IF EXISTS `semester`;
+CREATE TABLE IF NOT EXISTS `semester`
+(
+    `semester_id`   INT         NOT NULL AUTO_INCREMENT,
+    `semester_name` VARCHAR(50) NOT NULL,
+    PRIMARY KEY (`semester_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = latin1;
+
+-- Table structure for table `subject_details`
+DROP TABLE IF EXISTS `subject_details`;
+CREATE TABLE `subject_details`
+(
+    `subject_id`   INT          NOT NULL AUTO_INCREMENT,
+    `subject_name` VARCHAR(100) NOT NULL,
+    `course_id`    INT          NOT NULL,
+    `semester_id`  INT          NOT NULL,
+    PRIMARY KEY (`subject_id`),
+    CONSTRAINT `fk_course_subject` FOREIGN KEY (`course_id`) REFERENCES `course_details` (`course_id`),
+    CONSTRAINT `fk_semester_subject` FOREIGN KEY (`semester_id`) REFERENCES `semester` (`semester_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = latin1;
+
+-- Table structure for table `file_data`
+DROP TABLE IF EXISTS `file_data`;
+CREATE TABLE IF NOT EXISTS `file_data`
+(
+    `file_id`                INT          NOT NULL AUTO_INCREMENT,
+    `file_name`              VARCHAR(255) NOT NULL,
+    `file_type`              VARCHAR(100) NOT NULL,
+    `file_path`              VARCHAR(255) NOT NULL,
+    `file_size`              BIGINT       NOT NULL,
+    `uploader_department_id` INT          NOT NULL,
+    `uploader_name`          VARCHAR(255) NOT NULL,
+    `course_id`              INT          NOT NULL,
+    `semester_id`            INT          NOT NULL,
+    `subject_id`             INT          NOT NULL,
+    `uploaded_at`            TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `file_role`              VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`file_id`),
+    KEY `department_id` (`uploader_department_id`),
+    KEY `course_id` (`course_id`),
+    KEY `semester_id` (`semester_id`),
+    KEY `subject_id` (`subject_id`),
+    CONSTRAINT `fk_department_file` FOREIGN KEY (`uploader_department_id`) REFERENCES `department` (`department_id`),
+    CONSTRAINT `fk_course_file` FOREIGN KEY (`course_id`) REFERENCES `course_details` (`course_id`),
+    CONSTRAINT `fk_semester_file` FOREIGN KEY (`semester_id`) REFERENCES `semester` (`semester_id`),
+    CONSTRAINT `fk_subject_file` FOREIGN KEY (`subject_id`) REFERENCES `subject_details` (`subject_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = latin1;
+
+/*!40101 SET SQL_MODE = @OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS = @OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS = @OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT = @OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS = @OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION = @OLD_COLLATION_CONNECTION */;

--- a/Project/src/main/java/com/bitsunisage/campusconnect/project/controller/MasterController.java
+++ b/Project/src/main/java/com/bitsunisage/campusconnect/project/controller/MasterController.java
@@ -22,7 +22,7 @@ public class MasterController implements ErrorController {
 
     @GetMapping("/")
     public String showPublicLandingPage() {
-        return "/index";
+        return "index";
     }
 
 
@@ -36,7 +36,7 @@ public class MasterController implements ErrorController {
         }
         // If the attribute is not set, show the login page
 
-        return "/loginFile";
+        return "loginFile";
     }
 
 
@@ -56,7 +56,7 @@ public class MasterController implements ErrorController {
         model.addAttribute("members", userService.findAllUsers());
         model.addAttribute("roles", userService.findAllRoles());
         model.addAttribute("departments", userService.getAllDepartments());
-        return "/ReferralData";
+        return "ReferralData";
     }
 
 

--- a/Project/src/test/java/com/bitsunisage/campusconnect/project/controller/MasterControllerTest.java
+++ b/Project/src/test/java/com/bitsunisage/campusconnect/project/controller/MasterControllerTest.java
@@ -28,7 +28,7 @@ class MasterControllerTest {
     void landingPageReturnsIndexView() throws Exception {
         mockMvc.perform(get("/"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("/index"));
+                .andExpect(view().name("index"));
     }
 
     @Test
@@ -45,7 +45,7 @@ class MasterControllerTest {
     void loginPageWithNoSessionAttributeReturnsLoginView() throws Exception {
         mockMvc.perform(get("/login"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("/loginFile"));
+                .andExpect(view().name("loginFile"));
     }
 
     @Test
@@ -57,6 +57,6 @@ class MasterControllerTest {
         mockMvc.perform(get("/view-data"))
                 .andExpect(status().isOk())
                 .andExpect(model().attributeExists("members", "roles", "departments"))
-                .andExpect(view().name("/ReferralData"));
+                .andExpect(view().name("ReferralData"));
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  db:
+    image: mysql:8.0
+    env_file:
+      - ./Project/.env
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpassword}
+      MYSQL_DATABASE: campusConnect
+      MYSQL_USER: campusConnect
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./Project/docker/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "campusConnect", "-p${DB_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    ports:
+      - "3307:3306"
+
+  app:
+    build:
+      context: ./Project
+      dockerfile: Dockerfile
+    env_file:
+      - ./Project/.env
+    ports:
+      - "8080:8080"
+    environment:
+      DB_URL: jdbc:mysql://db:3306/campusConnect
+      DB_USERNAME: campusConnect
+      DB_PASSWORD: ${DB_PASSWORD}
+      UPLOAD_DIR: /uploads/
+    volumes:
+      - uploads:/uploads
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  mysql_data:
+  uploads:


### PR DESCRIPTION
## Summary

- **Dockerfile**: Multi-stage build — Maven compiles the JAR in stage 1; slim JRE Alpine image runs it in stage 2. Final image is ~200MB vs ~600MB for a single-stage build. App runs as a non-root user.
- **docker-compose.yml**: Wires the Spring Boot app and MySQL 8.0 together with a health check, named volumes for data persistence, and `env_file` loading from `Project/.env`.
- **Project/docker/init.sql**: Schema and seed data stripped of `CREATE DATABASE`/`CREATE USER` (MySQL image handles those via env vars on first boot).
- **Project/.dockerignore**: Excludes `target/`, `.idea/`, `.env` from the build context.
- **CI push-image job**: Runs after tests pass on merges to `main`. Builds the Docker image and pushes to GHCR tagged `:latest` and `:<commit-sha>`. Uses `GITHUB_TOKEN` — no extra secrets needed.
- **MasterController fix**: View names had a leading slash (`"/index"`) which broke Thymeleaf template resolution. Removed the leading slashes.

## How to run locally

```bash
docker compose --env-file Project/.env up --build
```

App at http://localhost:8080. MySQL accessible at localhost:3307.

## Test plan

- [ ] `docker compose --env-file Project/.env up --build -d` starts both containers cleanly
- [ ] `http://localhost:8080` loads the landing page
- [ ] Login works with dummy credentials (`admin1` / `password`)
- [ ] CI passes (Build & Test job)
- [ ] After merge, Push Docker Image job runs and image appears in GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)