### PR TITLE
Reference GHCR image in docker-compose for pull-and-run workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - "3307:3306"
 
   app:
+    image: ghcr.io/subodhadhikari2023/campusconnect:latest
     build:
       context: ./Project
       dockerfile: Dockerfile


### PR DESCRIPTION
Adding image: alongside build: enables two workflows:
  - docker compose up          → pulls pre-built image from GHCR
  - docker compose up --build  → builds locally from source