### PR TITLE
security: remove hardcoded DB password and add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_URL=jdbc:mysql://localhost:3306/campusConnect
+DB_USERNAME=campusConnect
+DB_PASSWORD=change-me
+MYSQL_ROOT_PASSWORD=change-me
+UPLOAD_DIR=uploads/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Requires MySQL Server 8.0+. Run the full schema and seed data as root:
 mysql -u root -p < sql-scripts/databaseScript.sql
 ```
 
-This creates the `campusConnect` database, the `campusConnect` MySQL user (password: `Frpsxwhu2001@`), all tables, and dummy users. The `departments.sql` script can be run separately for additional department seed data.
+This creates the `campusConnect` database, the `campusConnect` MySQL user (password from `DB_PASSWORD` in your `.env`), all tables, and dummy users. The `departments.sql` script can be run separately for additional department seed data.
 
 **Dummy credentials** (all use password `password`):
 - Admin: `admin1`, `admin2`

--- a/setup.sh
+++ b/setup.sh
@@ -132,8 +132,7 @@ else
     read -rs MYSQL_ROOT_PASS
     echo ""
 
-    if ! mysql -h "$DB_HOST" -P "$DB_PORT" -u root -p"$MYSQL_ROOT_PASS" \
-        < "$SQL_SCRIPT" 2>&1; then
+    if ! envsubst < "$SQL_SCRIPT" | mysql -h "$DB_HOST" -P "$DB_PORT" -u root -p"$MYSQL_ROOT_PASS" 2>&1; then
         error "Database setup failed. Check your root password and that MySQL is running."
     fi
     success "Database '$DB_NAME' created and seeded"

--- a/sql-scripts/databaseScript.sql
+++ b/sql-scripts/databaseScript.sql
@@ -19,7 +19,7 @@ CREATE DATABASE IF NOT EXISTS `campusConnect`;
 USE `campusConnect`;
 
 -- Create MySQL User and Grant Privileges
-CREATE USER IF NOT EXISTS `campusConnect`@`localhost` IDENTIFIED BY 'Frpsxwhu2001@';
+CREATE USER IF NOT EXISTS `campusConnect`@`localhost` IDENTIFIED BY '${DB_PASSWORD}';
 GRANT ALL PRIVILEGES ON `campusConnect`.* TO `campusConnect`@`localhost`;
 
 -- Table structure for table `department`


### PR DESCRIPTION
Replace the literal password in databaseScript.sql with ${DB_PASSWORD} (substituted via envsubst in setup.sh), scrub it from CLAUDE.md, and add .env.example as the canonical template for local env configuration.