### PR TITLE
feat(admin): make user list tables responsive and consistent

### DIFF
--- a/src/main/resources/templates/adminViewPages/gethod.html
+++ b/src/main/resources/templates/adminViewPages/gethod.html
@@ -9,51 +9,56 @@
 </head>
 <body>
 <div th:replace="~{adminViewPages/navbar :: navbar}"></div>
-<div class="container my-5">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2 class="mb-0">Heads of Department</h2>
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="fw-semibold" style="color: var(--clr-text);">Heads of Department</h2>
         <a th:href="@{/admin/add-user}" class="btn btn-primary btn-sm">+ Add User</a>
     </div>
 
     <div th:if="${userHODs.empty}" class="alert alert-info">No HODs registered yet.</div>
-    <table th:unless="${userHODs.empty}" class="table table-bordered table-hover align-middle">
-        <thead class="table-dark">
-        <tr>
-            <th>Username</th>
-            <th>Email</th>
-            <th>Department</th>
-            <th>Active</th>
-            <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="hod : ${userHODs}">
-            <td th:text="${hod.userId}"></td>
-            <td th:text="${hod.email}"></td>
-            <td th:text="${hod.department}"></td>
-            <td>
-                <form th:action="@{/admin/toggleActive}" method="POST" class="d-inline">
-                    <input type="hidden" name="userId" th:value="${hod.userId}">
-                    <input type="hidden" name="redirectTo" value="/admin/hods">
-                    <button type="submit"
-                            th:class="${hod.active} ? 'badge border-0 bg-success' : 'badge border-0 bg-secondary'"
-                            th:text="${hod.active} ? 'Active' : 'Inactive'"
-                            th:title="${hod.active} ? 'Click to deactivate' : 'Click to activate'"></button>
-                </form>
-            </td>
-            <td>
-                <a th:href="@{/admin/editUser(userId=${hod.userId})}"
-                   class="btn btn-sm btn-outline-primary me-1">Edit</a>
-                <form th:action="@{/admin/deleteUser}" method="POST" class="d-inline">
-                    <input type="hidden" name="userId" th:value="${hod.userId}">
-                    <button type="submit" class="btn btn-sm btn-outline-danger"
-                            th:data-name="${hod.userId}"
-                            onclick="return confirm('Delete user ' + this.dataset.name + '?')">Delete</button>
-                </form>
-            </td>
-        </tr>
-        </tbody>
-    </table>
+    <div th:unless="${userHODs.empty}"
+         class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead style="background-color: var(--clr-primary-light);">
+                <tr>
+                    <th scope="col">Username</th>
+                    <th scope="col">Email</th>
+                    <th scope="col">Department</th>
+                    <th scope="col">Active</th>
+                    <th scope="col">Actions</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="hod : ${userHODs}">
+                    <td th:text="${hod.userId}"></td>
+                    <td th:text="${hod.email}"></td>
+                    <td th:text="${hod.department}"></td>
+                    <td>
+                        <form th:action="@{/admin/toggleActive}" method="POST" class="d-inline">
+                            <input type="hidden" name="userId" th:value="${hod.userId}">
+                            <input type="hidden" name="redirectTo" value="/admin/hods">
+                            <button type="submit"
+                                    th:class="${hod.active} ? 'badge border-0 bg-success' : 'badge border-0 bg-secondary'"
+                                    th:text="${hod.active} ? 'Active' : 'Inactive'"
+                                    th:title="${hod.active} ? 'Click to deactivate' : 'Click to activate'"></button>
+                        </form>
+                    </td>
+                    <td>
+                        <a th:href="@{/admin/editUser(userId=${hod.userId})}"
+                           class="btn btn-sm btn-outline-primary me-1">Edit</a>
+                        <form th:action="@{/admin/deleteUser}" method="POST" class="d-inline">
+                            <input type="hidden" name="userId" th:value="${hod.userId}">
+                            <button type="submit" class="btn btn-sm btn-outline-danger"
+                                    th:data-name="${hod.userId}"
+                                    onclick="return confirm('Delete user ' + this.dataset.name + '?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
 </div>
 <div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>

--- a/src/main/resources/templates/adminViewPages/getstudents.html
+++ b/src/main/resources/templates/adminViewPages/getstudents.html
@@ -9,51 +9,56 @@
 </head>
 <body>
 <div th:replace="~{adminViewPages/navbar :: navbar}"></div>
-<div class="container my-5">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2 class="mb-0">Students</h2>
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="fw-semibold" style="color: var(--clr-text);">Students</h2>
         <a th:href="@{/admin/add-user}" class="btn btn-primary btn-sm">+ Add User</a>
     </div>
 
     <div th:if="${userStudents.empty}" class="alert alert-info">No students registered yet.</div>
-    <table th:unless="${userStudents.empty}" class="table table-bordered table-hover align-middle">
-        <thead class="table-dark">
-        <tr>
-            <th>Username</th>
-            <th>Email</th>
-            <th>Department</th>
-            <th>Active</th>
-            <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="student : ${userStudents}">
-            <td th:text="${student.userId}"></td>
-            <td th:text="${student.email}"></td>
-            <td th:text="${student.department}"></td>
-            <td>
-                <form th:action="@{/admin/toggleActive}" method="POST" class="d-inline">
-                    <input type="hidden" name="userId" th:value="${student.userId}">
-                    <input type="hidden" name="redirectTo" value="/admin/students">
-                    <button type="submit"
-                            th:class="${student.active} ? 'badge border-0 bg-success' : 'badge border-0 bg-secondary'"
-                            th:text="${student.active} ? 'Active' : 'Inactive'"
-                            th:title="${student.active} ? 'Click to deactivate' : 'Click to activate'"></button>
-                </form>
-            </td>
-            <td>
-                <a th:href="@{/admin/editUser(userId=${student.userId})}"
-                   class="btn btn-sm btn-outline-primary me-1">Edit</a>
-                <form th:action="@{/admin/deleteUser}" method="POST" class="d-inline">
-                    <input type="hidden" name="userId" th:value="${student.userId}">
-                    <button type="submit" class="btn btn-sm btn-outline-danger"
-                            th:data-name="${student.userId}"
-                            onclick="return confirm('Delete user ' + this.dataset.name + '?')">Delete</button>
-                </form>
-            </td>
-        </tr>
-        </tbody>
-    </table>
+    <div th:unless="${userStudents.empty}"
+         class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead style="background-color: var(--clr-primary-light);">
+                <tr>
+                    <th scope="col">Username</th>
+                    <th scope="col">Email</th>
+                    <th scope="col">Department</th>
+                    <th scope="col">Active</th>
+                    <th scope="col">Actions</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="student : ${userStudents}">
+                    <td th:text="${student.userId}"></td>
+                    <td th:text="${student.email}"></td>
+                    <td th:text="${student.department}"></td>
+                    <td>
+                        <form th:action="@{/admin/toggleActive}" method="POST" class="d-inline">
+                            <input type="hidden" name="userId" th:value="${student.userId}">
+                            <input type="hidden" name="redirectTo" value="/admin/students">
+                            <button type="submit"
+                                    th:class="${student.active} ? 'badge border-0 bg-success' : 'badge border-0 bg-secondary'"
+                                    th:text="${student.active} ? 'Active' : 'Inactive'"
+                                    th:title="${student.active} ? 'Click to deactivate' : 'Click to activate'"></button>
+                        </form>
+                    </td>
+                    <td>
+                        <a th:href="@{/admin/editUser(userId=${student.userId})}"
+                           class="btn btn-sm btn-outline-primary me-1">Edit</a>
+                        <form th:action="@{/admin/deleteUser}" method="POST" class="d-inline">
+                            <input type="hidden" name="userId" th:value="${student.userId}">
+                            <button type="submit" class="btn btn-sm btn-outline-danger"
+                                    th:data-name="${student.userId}"
+                                    onclick="return confirm('Delete user ' + this.dataset.name + '?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
 </div>
 <div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>

--- a/src/main/resources/templates/adminViewPages/getteachers.html
+++ b/src/main/resources/templates/adminViewPages/getteachers.html
@@ -9,51 +9,56 @@
 </head>
 <body>
 <div th:replace="~{adminViewPages/navbar :: navbar}"></div>
-<div class="container my-5">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2 class="mb-0">Teachers</h2>
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="fw-semibold" style="color: var(--clr-text);">Teachers</h2>
         <a th:href="@{/admin/add-user}" class="btn btn-primary btn-sm">+ Add User</a>
     </div>
 
     <div th:if="${userTeachers.empty}" class="alert alert-info">No teachers registered yet.</div>
-    <table th:unless="${userTeachers.empty}" class="table table-bordered table-hover align-middle">
-        <thead class="table-dark">
-        <tr>
-            <th>Username</th>
-            <th>Email</th>
-            <th>Department</th>
-            <th>Active</th>
-            <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="teacher : ${userTeachers}">
-            <td th:text="${teacher.userId}"></td>
-            <td th:text="${teacher.email}"></td>
-            <td th:text="${teacher.department}"></td>
-            <td>
-                <form th:action="@{/admin/toggleActive}" method="POST" class="d-inline">
-                    <input type="hidden" name="userId" th:value="${teacher.userId}">
-                    <input type="hidden" name="redirectTo" value="/admin/teachers">
-                    <button type="submit"
-                            th:class="${teacher.active} ? 'badge border-0 bg-success' : 'badge border-0 bg-secondary'"
-                            th:text="${teacher.active} ? 'Active' : 'Inactive'"
-                            th:title="${teacher.active} ? 'Click to deactivate' : 'Click to activate'"></button>
-                </form>
-            </td>
-            <td>
-                <a th:href="@{/admin/editUser(userId=${teacher.userId})}"
-                   class="btn btn-sm btn-outline-primary me-1">Edit</a>
-                <form th:action="@{/admin/deleteUser}" method="POST" class="d-inline">
-                    <input type="hidden" name="userId" th:value="${teacher.userId}">
-                    <button type="submit" class="btn btn-sm btn-outline-danger"
-                            th:data-name="${teacher.userId}"
-                            onclick="return confirm('Delete user ' + this.dataset.name + '?')">Delete</button>
-                </form>
-            </td>
-        </tr>
-        </tbody>
-    </table>
+    <div th:unless="${userTeachers.empty}"
+         class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead style="background-color: var(--clr-primary-light);">
+                <tr>
+                    <th scope="col">Username</th>
+                    <th scope="col">Email</th>
+                    <th scope="col">Department</th>
+                    <th scope="col">Active</th>
+                    <th scope="col">Actions</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="teacher : ${userTeachers}">
+                    <td th:text="${teacher.userId}"></td>
+                    <td th:text="${teacher.email}"></td>
+                    <td th:text="${teacher.department}"></td>
+                    <td>
+                        <form th:action="@{/admin/toggleActive}" method="POST" class="d-inline">
+                            <input type="hidden" name="userId" th:value="${teacher.userId}">
+                            <input type="hidden" name="redirectTo" value="/admin/teachers">
+                            <button type="submit"
+                                    th:class="${teacher.active} ? 'badge border-0 bg-success' : 'badge border-0 bg-secondary'"
+                                    th:text="${teacher.active} ? 'Active' : 'Inactive'"
+                                    th:title="${teacher.active} ? 'Click to deactivate' : 'Click to activate'"></button>
+                        </form>
+                    </td>
+                    <td>
+                        <a th:href="@{/admin/editUser(userId=${teacher.userId})}"
+                           class="btn btn-sm btn-outline-primary me-1">Edit</a>
+                        <form th:action="@{/admin/deleteUser}" method="POST" class="d-inline">
+                            <input type="hidden" name="userId" th:value="${teacher.userId}">
+                            <button type="submit" class="btn btn-sm btn-outline-danger"
+                                    th:data-name="${teacher.userId}"
+                                    onclick="return confirm('Delete user ' + this.dataset.name + '?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
 </div>
 <div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>


### PR DESCRIPTION
## Summary

- Wrapped `getstudents`, `getteachers`, and `gethod` tables in a card + `.table-responsive` div — these were the only three admin list pages missing responsive table wrapping (the other five pages already had it)
- Replaced `table-dark` thead with the teal `var(--clr-primary-light)` background, matching the consistent style used on `files.html`, `departments.html`, `semesters.html`, `courses.html`, and `inactive-users.html`
- Changed top-level container from `my-5` to `mt-4` for consistent page spacing across all admin list views
- Added `scope="col"` to all `<th>` header cells for accessibility

## Test plan

- [ ] Students, Teachers, and HODs list pages scroll horizontally on narrow viewports without breaking layout
- [ ] Thead colour matches teal primary-light (not dark)
- [ ] Active/Inactive toggle badges and Edit/Delete actions still work correctly
- [ ] CI passes