### PR TITLE
Add fixed sidebar navigation panel with mobile off-canvas drawer for the admin module

### DIFF
--- a/src/main/java/com/bitsunisage/campusconnect/config/GlobalModelAttributes.java
+++ b/src/main/java/com/bitsunisage/campusconnect/config/GlobalModelAttributes.java
@@ -1,5 +1,6 @@
 package com.bitsunisage.campusconnect.config;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
@@ -18,5 +19,14 @@ public class GlobalModelAttributes {
     @ModelAttribute("currentYear")
     public int currentYear() {
         return Year.now().getValue();
+    }
+
+    /**
+     * @param request the current HTTP request
+     * @return the URI path of the current request, used for active-link detection in nav fragments
+     */
+    @ModelAttribute("currentUri")
+    public String currentUri(HttpServletRequest request) {
+        return request.getRequestURI();
     }
 }

--- a/src/main/resources/static/CSS/admin/main.css
+++ b/src/main/resources/static/CSS/admin/main.css
@@ -10,6 +10,7 @@
     --clr-danger:         #dc3545;
     --clr-danger-dark:    #b02a37;
     --clr-success:        #198754;
+    --clr-warning:        #f59e0b;
 
     /* Surfaces */
     --clr-bg:             #f5f7fa;
@@ -33,20 +34,263 @@
 
     /* Motion */
     --transition-base:    0.3s ease;
+
+    /* Sidebar */
+    --sidebar-w:          240px;
+    --sidebar-bg:         #0f1f1f;
+    --sidebar-border:     rgba(255, 255, 255, 0.07);
+    --topbar-h:           56px;
 }
+
+/* ── Base ───────────────────────────────────────────────────── */
+
+*, *::before, *::after { box-sizing: border-box; }
 
 body {
     margin: 0;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background-color: var(--clr-bg);
     color: var(--clr-text);
-    min-height: 100vh;
+    font-size: 1rem;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* ── Layout shell ───────────────────────────────────────────── */
+
+.admin-page-content {
     display: flex;
     flex-direction: column;
+    min-height: 100vh;
 }
 
 .admin-main {
     flex: 1 0 auto;
+}
+
+/* Admin container: controlled padding instead of Bootstrap container */
+.admin-container {
+    padding: 1.25rem 1rem 2rem;
+}
+
+@media (min-width: 576px) {
+    .admin-container { padding: 1.5rem 1.5rem 2rem; }
+}
+
+/* ── Mobile topbar (visible only below lg) ──────────────────── */
+
+.admin-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 200;
+    height: var(--topbar-h);
+    background: var(--clr-surface);
+    border-bottom: 1px solid var(--clr-border);
+    box-shadow: var(--shadow-sm);
+    padding: 0 1rem;
+    gap: 0.75rem;
+}
+
+.admin-topbar__toggle {
+    background: none;
+    border: none;
+    padding: 0.3rem;
+    cursor: pointer;
+    color: var(--clr-text);
+    display: flex;
+    align-items: center;
+    border-radius: var(--radius-sm);
+    transition: background var(--transition-base);
+}
+
+.admin-topbar__toggle:hover {
+    background: var(--clr-bg);
+}
+
+.admin-topbar__brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none;
+    color: var(--clr-text);
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.admin-topbar__brand img {
+    max-height: 32px;
+    width: auto;
+}
+
+/* ── Sidebar (off-canvas on mobile, fixed on desktop) ───────── */
+
+.admin-sidebar {
+    width: var(--sidebar-w) !important;
+    background: var(--sidebar-bg) !important;
+    border-right: 1px solid var(--sidebar-border);
+    display: flex !important;
+    flex-direction: column;
+}
+
+/* Desktop: always-visible fixed sidebar, override Bootstrap offcanvas */
+@media (min-width: 992px) {
+    .admin-sidebar {
+        position: fixed !important;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        transform: none !important;
+        visibility: visible !important;
+        z-index: 100;
+        overflow-y: auto;
+    }
+
+    .admin-page-content {
+        margin-left: var(--sidebar-w);
+    }
+}
+
+/* Sidebar header */
+.admin-sidebar__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem 1.1rem 1rem;
+    border-bottom: 1px solid var(--sidebar-border);
+    flex-shrink: 0;
+}
+
+.admin-sidebar__brand {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    text-decoration: none;
+}
+
+.admin-sidebar__brand img {
+    max-height: 34px;
+    width: auto;
+}
+
+.admin-sidebar__brand span {
+    font-size: 0.88rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.9);
+    letter-spacing: 0.01em;
+}
+
+.admin-sidebar__close {
+    background: none;
+    border: none;
+    padding: 0.3rem;
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.45);
+    display: flex;
+    align-items: center;
+    border-radius: var(--radius-sm);
+    transition: color var(--transition-base), background var(--transition-base);
+}
+
+.admin-sidebar__close:hover {
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+/* Sidebar nav */
+.admin-sidebar__nav {
+    flex: 1;
+    padding: 0.75rem 0;
+    overflow-y: auto;
+}
+
+.admin-sidebar__group-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.3);
+    padding: 1rem 1.1rem 0.3rem;
+    user-select: none;
+}
+
+.admin-sidebar__link {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.6rem 1.1rem;
+    color: rgba(255, 255, 255, 0.62);
+    text-decoration: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border-left: 3px solid transparent;
+    transition: background var(--transition-base), color var(--transition-base),
+                border-left-color var(--transition-base);
+}
+
+.admin-sidebar__link:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.92);
+    border-left-color: rgba(0, 122, 122, 0.5);
+}
+
+.admin-sidebar__link.is-active {
+    background: rgba(0, 122, 122, 0.18);
+    color: #ffffff;
+    border-left-color: var(--clr-primary);
+    font-weight: 600;
+}
+
+.admin-sidebar__link--dashboard {
+    border-bottom: 1px solid var(--sidebar-border);
+    margin-bottom: 0.25rem;
+    padding-bottom: 0.75rem;
+}
+
+.admin-sidebar__link--warn {
+    color: rgba(245, 158, 11, 0.75);
+}
+
+.admin-sidebar__link--warn:hover,
+.admin-sidebar__link--warn.is-active {
+    color: #f59e0b;
+    background: rgba(245, 158, 11, 0.1);
+    border-left-color: #f59e0b;
+}
+
+.admin-sidebar__divider {
+    height: 1px;
+    background: var(--sidebar-border);
+    margin: 0.5rem 1.1rem;
+}
+
+/* Sidebar footer */
+.admin-sidebar__foot {
+    padding: 0.85rem 1.1rem;
+    border-top: 1px solid var(--sidebar-border);
+    flex-shrink: 0;
+}
+
+.admin-sidebar__logout {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: rgba(220, 53, 69, 0.12);
+    color: #f87171;
+    border: 1px solid rgba(220, 53, 69, 0.25);
+    border-radius: var(--radius-md);
+    padding: 0.55rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--transition-base), border-color var(--transition-base);
+}
+
+.admin-sidebar__logout:hover {
+    background: rgba(220, 53, 69, 0.22);
+    border-color: rgba(220, 53, 69, 0.45);
+    color: #fca5a5;
 }
 
 /* ── Section label ──────────────────────────────────────────── */

--- a/src/main/resources/templates/adminViewPages/add-department.html
+++ b/src/main/resources/templates/adminViewPages/add-department.html
@@ -8,11 +8,14 @@
     <link rel="stylesheet" th:href="@{/CSS/admin/userAddForm.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-<div class="container mt-5">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
     <div class="row justify-content-center">
-        <div class="col-md-7 col-lg-6">
+        <div class="col-12 col-md-8 col-lg-6">
             <div class="form-card">
                 <div class="form-card-title"
                      th:text="${dept.id != null} ? 'Edit Department: ' + ${dept.name} : 'Add Department'">
@@ -35,7 +38,7 @@
                                th:field="*{name}" placeholder="Enter department name">
                     </div>
 
-                    <div class="d-flex gap-2">
+                    <div class="d-flex gap-2 flex-wrap">
                         <button class="btn btn-primary" type="submit"
                                 th:text="${dept.id != null} ? 'Update Department' : 'Add Department'">
                             Add Department
@@ -46,9 +49,12 @@
             </div>
         </div>
     </div>
+
+</div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
 </div>
 
-<div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/add-semester.html
+++ b/src/main/resources/templates/adminViewPages/add-semester.html
@@ -8,11 +8,14 @@
     <link rel="stylesheet" th:href="@{/CSS/admin/userAddForm.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-<div class="container mt-5">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
     <div class="row justify-content-center">
-        <div class="col-md-7 col-lg-6">
+        <div class="col-12 col-md-8 col-lg-6">
             <div class="form-card">
                 <div class="form-card-title"
                      th:text="${semester.semesterId != null} ? 'Edit Semester' : 'Add Semester'">
@@ -28,7 +31,7 @@
                                th:field="*{semesterName}" placeholder="e.g. Semester I">
                     </div>
 
-                    <div class="d-flex gap-2">
+                    <div class="d-flex gap-2 flex-wrap">
                         <button class="btn btn-primary" type="submit"
                                 th:text="${semester.semesterId != null} ? 'Update Semester' : 'Add Semester'">
                             Add Semester
@@ -39,9 +42,12 @@
             </div>
         </div>
     </div>
+
+</div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
 </div>
 
-<div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/add-user.html
+++ b/src/main/resources/templates/adminViewPages/add-user.html
@@ -10,11 +10,14 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet"/>
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-<div class="container mt-5">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
     <div class="row justify-content-center">
-        <div class="col-md-7 col-lg-6">
+        <div class="col-12 col-md-8 col-lg-6">
             <div class="form-card">
                 <div class="form-card-title"
                      th:text="${user.userId != null and !#strings.isEmpty(user.userId)} ? 'Edit User: ' + ${user.userId} : 'Add New User'">
@@ -75,7 +78,7 @@
                         </div>
                     </div>
 
-                    <div class="d-flex gap-2">
+                    <div class="d-flex gap-2 flex-wrap">
                         <button class="btn btn-primary" type="submit"
                                 th:text="${user.userId != null and !#strings.isEmpty(user.userId)} ? 'Update User' : 'Add User'">
                             Add User
@@ -86,9 +89,12 @@
             </div>
         </div>
     </div>
+
+</div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
 </div>
 
-<div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/javascript/Admin/togglepassword.js}"></script>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>

--- a/src/main/resources/templates/adminViewPages/admin.html
+++ b/src/main/resources/templates/adminViewPages/admin.html
@@ -8,12 +8,14 @@
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-<main class="admin-main container mt-4">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
 
     <!-- Welcome header -->
-    <div class="d-flex align-items-baseline justify-content-between mb-3">
+    <div class="d-flex align-items-baseline justify-content-between flex-wrap gap-2 mb-3">
         <h5 class="mb-0">Welcome, <strong sec:authentication="principal.username"></strong></h5>
         <span class="text-muted" style="font-size:0.85rem;"
               th:text="${totalUsers} + ' registered users'"></span>
@@ -111,14 +113,16 @@
                 </span>
             </li>
         </ul>
-        <p th:if="${#lists.isEmpty(recentFiles)}" class="text-muted mb-0 p-2">
+        <p th:if="${#lists.isEmpty(recentFiles)}" class="text-muted mb-0 p-3">
             No files uploaded yet.
         </p>
     </div>
 
+</div>
 </main>
-
 <div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/assign-hod.html
+++ b/src/main/resources/templates/adminViewPages/assign-hod.html
@@ -8,52 +8,65 @@
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
-<div class="container mt-4" style="max-width:540px;">
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-    <div class="d-flex align-items-center gap-2 mb-4">
-        <a th:href="@{/admin/departments}" class="btn btn-sm btn-outline-secondary">&larr; Back</a>
-        <h2 class="mb-0 fs-4" th:text="'Assign HOD — ' + ${dept.name}">Assign HOD</h2>
-    </div>
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
 
-    <div class="card shadow-sm" style="border-radius: var(--radius-lg); border-color: var(--clr-border);">
-        <div class="card-body p-4">
-            <form th:action="@{/admin/save-hod-assignment}" method="POST">
-                <input type="hidden" name="deptId" th:value="${dept.id}">
+    <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6">
 
-                <div class="mb-3">
-                    <label class="form-label fw-semibold">Department</label>
-                    <input type="text" class="form-control" th:value="${dept.name}" readonly>
+            <div class="d-flex align-items-center gap-2 mb-4">
+                <a th:href="@{/admin/departments}" class="btn btn-sm btn-outline-secondary">&larr; Back</a>
+                <h2 class="mb-0 fs-5 fw-semibold" th:text="'Assign HOD — ' + ${dept.name}">Assign HOD</h2>
+            </div>
+
+            <div class="card shadow-sm" style="border-radius: var(--radius-lg); border-color: var(--clr-border);">
+                <div class="card-body p-4">
+                    <form th:action="@{/admin/save-hod-assignment}" method="POST">
+                        <input type="hidden" name="deptId" th:value="${dept.id}">
+
+                        <div class="mb-3">
+                            <label class="form-label fw-semibold">Department</label>
+                            <input type="text" class="form-control" th:value="${dept.name}" readonly>
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="hodSelect" class="form-label fw-semibold">Select HOD</label>
+                            <div th:if="${hods.empty}" class="alert alert-warning mb-0">
+                                No HOD accounts exist yet.
+                                <a th:href="@{/admin/add-user}">Create one first.</a>
+                            </div>
+                            <select th:unless="${hods.empty}" id="hodSelect" name="hodUserId"
+                                    class="form-select" required>
+                                <option value="" disabled th:selected="${currentHodId == null}">— select a HOD —</option>
+                                <option th:each="hod : ${hods}"
+                                        th:value="${hod.userId}"
+                                        th:text="${hod.userId} + ' (' + ${hod.department} + ')'"
+                                        th:selected="${hod.userId == currentHodId}"></option>
+                            </select>
+                            <div th:if="${currentHodId != null}" class="form-text">
+                                Current HOD: <strong th:text="${currentHodId}"></strong>
+                            </div>
+                        </div>
+
+                        <div class="d-flex gap-2 flex-wrap" th:unless="${hods.empty}">
+                            <button type="submit" class="btn btn-primary">Save Assignment</button>
+                            <a th:href="@{/admin/departments}" class="btn btn-outline-secondary">Cancel</a>
+                        </div>
+                    </form>
                 </div>
+            </div>
 
-                <div class="mb-4">
-                    <label for="hodSelect" class="form-label fw-semibold">Select HOD</label>
-                    <div th:if="${hods.empty}" class="alert alert-warning mb-0">
-                        No HOD accounts exist yet.
-                        <a th:href="@{/admin/add-user}">Create one first.</a>
-                    </div>
-                    <select th:unless="${hods.empty}" id="hodSelect" name="hodUserId"
-                            class="form-select" required>
-                        <option value="" disabled th:selected="${currentHodId == null}">— select a HOD —</option>
-                        <option th:each="hod : ${hods}"
-                                th:value="${hod.userId}"
-                                th:text="${hod.userId} + ' (' + ${hod.department} + ')'"
-                                th:selected="${hod.userId == currentHodId}"></option>
-                    </select>
-                    <div th:if="${currentHodId != null}" class="form-text">
-                        Current HOD: <strong th:text="${currentHodId}"></strong>
-                    </div>
-                </div>
-
-                <div class="d-flex gap-2" th:unless="${hods.empty}">
-                    <button type="submit" class="btn btn-primary">Save Assignment</button>
-                    <a th:href="@{/admin/departments}" class="btn btn-outline-secondary">Cancel</a>
-                </div>
-            </form>
         </div>
     </div>
+
 </div>
+</main>
 <div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/courses.html
+++ b/src/main/resources/templates/adminViewPages/courses.html
@@ -3,16 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
-    <title>Courses</title>
+    <title>Courses &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-<div class="container mt-4">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
 
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2 class="fw-semibold" style="color: var(--clr-text);">Courses</h2>
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">Courses</h2>
     </div>
 
     <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
@@ -32,7 +34,7 @@
     <div th:unless="${#lists.isEmpty(courses)}"
          class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
         <div class="table-responsive">
-            <table class="table table-hover mb-0">
+            <table class="table table-hover mb-0 align-middle">
                 <thead style="background-color: var(--clr-primary-light);">
                 <tr>
                     <th scope="col">Department</th>
@@ -48,9 +50,12 @@
             </table>
         </div>
     </div>
+
+</div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
 </div>
 
-<div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/departments.html
+++ b/src/main/resources/templates/adminViewPages/departments.html
@@ -3,17 +3,19 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
-    <title>Departments</title>
+    <title>Departments &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-<div class="container mt-4">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
 
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2 class="fw-semibold" style="color: var(--clr-text);">Departments</h2>
-        <a th:href="@{/admin/add-department}" class="btn btn-primary">Add Department</a>
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">Departments</h2>
+        <a th:href="@{/admin/add-department}" class="btn btn-primary btn-sm">+ Add Department</a>
     </div>
 
     <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
@@ -33,7 +35,7 @@
     <div th:unless="${#lists.isEmpty(departments)}"
          class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
         <div class="table-responsive">
-            <table class="table table-hover mb-0">
+            <table class="table table-hover mb-0 align-middle">
                 <thead style="background-color: var(--clr-primary-light);">
                 <tr>
                     <th scope="col">ID</th>
@@ -57,8 +59,7 @@
                            class="btn btn-sm btn-outline-secondary me-1">Assign HOD</a>
                         <a th:href="@{/admin/editDepartment(id=${dept.id})}"
                            class="btn btn-sm btn-outline-primary me-1">Edit</a>
-                        <form th:action="@{/admin/delete-department}" method="POST"
-                              style="display: inline;">
+                        <form th:action="@{/admin/delete-department}" method="POST" class="d-inline">
                             <input type="hidden" name="deptId" th:value="${dept.id}"/>
                             <button type="submit" class="btn btn-sm btn-outline-danger"
                                     th:data-name="${dept.name}"
@@ -72,9 +73,12 @@
             </table>
         </div>
     </div>
+
+</div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
 </div>
 
-<div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/files.html
+++ b/src/main/resources/templates/adminViewPages/files.html
@@ -3,16 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
-    <title>Files</title>
+    <title>Files &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-<div class="container mt-4">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
 
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2 class="fw-semibold" style="color: var(--clr-text);">File Moderation</h2>
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">File Moderation</h2>
     </div>
 
     <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
@@ -32,7 +34,7 @@
     <div th:unless="${#lists.isEmpty(files)}"
          class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
         <div class="table-responsive">
-            <table class="table table-hover mb-0">
+            <table class="table table-hover mb-0 align-middle">
                 <thead style="background-color: var(--clr-primary-light);">
                 <tr>
                     <th scope="col">File Name</th>
@@ -53,7 +55,7 @@
                     <td th:text="${deptNames[file.fileDepartmentId] ?: 'Unknown'}"></td>
                     <td th:text="${#temporals.format(file.uploadDate.toLocalDateTime(), 'dd MMM yyyy HH:mm')}"></td>
                     <td>
-                        <form th:action="@{/admin/delete-file}" method="POST" style="display: inline;">
+                        <form th:action="@{/admin/delete-file}" method="POST" class="d-inline">
                             <input type="hidden" name="fileId" th:value="${file.id}"/>
                             <button type="submit" class="btn btn-sm btn-outline-danger"
                                     th:data-name="${file.fileName}"
@@ -67,9 +69,12 @@
             </table>
         </div>
     </div>
+
+</div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
 </div>
 
-<div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/gethod.html
+++ b/src/main/resources/templates/adminViewPages/gethod.html
@@ -4,14 +4,18 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
-    <title>HODs</title>
+    <title>HODs &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
-<div class="container mt-4">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2 class="fw-semibold" style="color: var(--clr-text);">Heads of Department</h2>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
+
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">Heads of Department</h2>
         <a th:href="@{/admin/add-user}" class="btn btn-primary btn-sm">+ Add User</a>
     </div>
 
@@ -19,7 +23,7 @@
     <div th:unless="${userHODs.empty}"
          class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
         <div class="table-responsive">
-            <table class="table table-hover mb-0">
+            <table class="table table-hover mb-0 align-middle">
                 <thead style="background-color: var(--clr-primary-light);">
                 <tr>
                     <th scope="col">Username</th>
@@ -59,8 +63,12 @@
             </table>
         </div>
     </div>
+
 </div>
+</main>
 <div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/getstudents.html
+++ b/src/main/resources/templates/adminViewPages/getstudents.html
@@ -4,14 +4,18 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
-    <title>Students</title>
+    <title>Students &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
-<div class="container mt-4">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2 class="fw-semibold" style="color: var(--clr-text);">Students</h2>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
+
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">Students</h2>
         <a th:href="@{/admin/add-user}" class="btn btn-primary btn-sm">+ Add User</a>
     </div>
 
@@ -19,7 +23,7 @@
     <div th:unless="${userStudents.empty}"
          class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
         <div class="table-responsive">
-            <table class="table table-hover mb-0">
+            <table class="table table-hover mb-0 align-middle">
                 <thead style="background-color: var(--clr-primary-light);">
                 <tr>
                     <th scope="col">Username</th>
@@ -59,8 +63,12 @@
             </table>
         </div>
     </div>
+
 </div>
+</main>
 <div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/getteachers.html
+++ b/src/main/resources/templates/adminViewPages/getteachers.html
@@ -4,14 +4,18 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
-    <title>Teachers</title>
+    <title>Teachers &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
-<div class="container mt-4">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2 class="fw-semibold" style="color: var(--clr-text);">Teachers</h2>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
+
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">Teachers</h2>
         <a th:href="@{/admin/add-user}" class="btn btn-primary btn-sm">+ Add User</a>
     </div>
 
@@ -19,7 +23,7 @@
     <div th:unless="${userTeachers.empty}"
          class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
         <div class="table-responsive">
-            <table class="table table-hover mb-0">
+            <table class="table table-hover mb-0 align-middle">
                 <thead style="background-color: var(--clr-primary-light);">
                 <tr>
                     <th scope="col">Username</th>
@@ -59,8 +63,12 @@
             </table>
         </div>
     </div>
+
 </div>
+</main>
 <div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/inactive-users.html
+++ b/src/main/resources/templates/adminViewPages/inactive-users.html
@@ -3,16 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
-    <title>Inactive Users</title>
+    <title>Inactive Users &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-<div class="container mt-4">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
 
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2 class="fw-semibold" style="color: var(--clr-text);">Inactive Users</h2>
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">Inactive Users</h2>
     </div>
 
     <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
@@ -32,7 +34,7 @@
     <div th:unless="${#lists.isEmpty(inactiveUsers)}"
          class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
         <div class="table-responsive">
-            <table class="table table-hover mb-0">
+            <table class="table table-hover mb-0 align-middle">
                 <thead style="background-color: var(--clr-primary-light);">
                 <tr>
                     <th scope="col">Username</th>
@@ -58,9 +60,12 @@
             </table>
         </div>
     </div>
+
+</div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
 </div>
 
-<div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/semesters.html
+++ b/src/main/resources/templates/adminViewPages/semesters.html
@@ -3,17 +3,19 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
-    <title>Semesters</title>
+    <title>Semesters &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{adminViewPages/navbar :: navbar}"></div>
+<div th:replace="~{adminViewPages/sidebar :: sidebar}"></div>
 
-<div class="container mt-4">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
 
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2 class="fw-semibold" style="color: var(--clr-text);">Semesters</h2>
-        <a th:href="@{/admin/add-semester}" class="btn btn-primary">Add Semester</a>
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">Semesters</h2>
+        <a th:href="@{/admin/add-semester}" class="btn btn-primary btn-sm">+ Add Semester</a>
     </div>
 
     <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
@@ -33,7 +35,7 @@
     <div th:unless="${#lists.isEmpty(semesters)}"
          class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
         <div class="table-responsive">
-            <table class="table table-hover mb-0">
+            <table class="table table-hover mb-0 align-middle">
                 <thead style="background-color: var(--clr-primary-light);">
                 <tr>
                     <th scope="col">ID</th>
@@ -48,8 +50,7 @@
                     <td>
                         <a th:href="@{/admin/editSemester(semesterId=${sem.semesterId})}"
                            class="btn btn-sm btn-outline-primary me-1">Edit</a>
-                        <form th:action="@{/admin/delete-semester}" method="POST"
-                              style="display: inline;">
+                        <form th:action="@{/admin/delete-semester}" method="POST" class="d-inline">
                             <input type="hidden" name="semesterId" th:value="${sem.semesterId}"/>
                             <button type="submit" class="btn btn-sm btn-outline-danger"
                                     th:data-name="${sem.semesterName}"
@@ -63,9 +64,12 @@
             </table>
         </div>
     </div>
+
+</div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
 </div>
 
-<div th:replace="~{adminViewPages/footer :: footer}"></div>
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/adminViewPages/sidebar.html
+++ b/src/main/resources/templates/adminViewPages/sidebar.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org/">
+<body>
+<div th:fragment="sidebar">
+
+    <!-- ── Mobile topbar (hidden on lg+) ──────────────────── -->
+    <nav class="admin-topbar d-flex d-lg-none align-items-center">
+        <button class="admin-topbar__toggle" type="button"
+                data-bs-toggle="offcanvas" data-bs-target="#adminSidebar"
+                aria-controls="adminSidebar" aria-label="Open navigation">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 16 16" fill="currentColor">
+                <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+            </svg>
+        </button>
+        <a class="admin-topbar__brand" th:href="@{/admin}">
+            <img th:src="@{/loginResources/images/main-logo-black-transparent.png}" alt="CampusConnect">
+            <span>Admin Panel</span>
+        </a>
+    </nav>
+
+    <!-- ── Sidebar (off-canvas on mobile, fixed on desktop) ── -->
+    <aside class="admin-sidebar offcanvas offcanvas-start"
+           tabindex="-1" id="adminSidebar" aria-labelledby="adminSidebarLabel">
+
+        <!-- Sidebar header -->
+        <div class="admin-sidebar__head">
+            <a class="admin-sidebar__brand" th:href="@{/admin}" id="adminSidebarLabel">
+                <img th:src="@{/loginResources/images/main-logo-white-transparent.png}" alt="CampusConnect">
+                <span>Admin Panel</span>
+            </a>
+            <button type="button" class="admin-sidebar__close d-lg-none"
+                    data-bs-dismiss="offcanvas" aria-label="Close">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854z"/>
+                </svg>
+            </button>
+        </div>
+
+        <!-- Navigation -->
+        <nav class="admin-sidebar__nav" aria-label="Admin navigation">
+
+            <!-- Dashboard -->
+            <a th:href="@{/admin}"
+               th:classappend="${currentUri == '/admin'} ? ' is-active'"
+               class="admin-sidebar__link admin-sidebar__link--dashboard">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M8 4a.5.5 0 0 1 .5.5V6a.5.5 0 0 1-1 0V4.5A.5.5 0 0 1 8 4zM3.732 5.732a.5.5 0 0 1 .707 0l.915.914a.5.5 0 1 1-.708.708l-.914-.915a.5.5 0 0 1 0-.707zM2 10a.5.5 0 0 1 .5-.5h1.586a.5.5 0 0 1 0 1H2.5A.5.5 0 0 1 2 10zm9.5 0a.5.5 0 0 1 .5-.5h1.5a.5.5 0 0 1 0 1H12a.5.5 0 0 1-.5-.5zm.754-4.246a.389.389 0 0 0-.527-.02L7.547 9.31a.91.91 0 1 0 1.302 1.258l3.434-4.297a.389.389 0 0 0-.029-.518z"/>
+                    <path fill-rule="evenodd" d="M0 10a8 8 0 1 1 15.547 2.661c-.442 1.253-1.845 1.602-2.932 1.25C11.309 13.488 9.475 13 8 13c-1.474 0-3.31.488-4.615.911-1.087.352-2.49.003-2.932-1.25A7.988 7.988 0 0 1 0 10zm8-7a7 7 0 0 0-6.603 9.329c.203.575.923.876 1.68.63C4.397 12.533 6.358 12 8 12s3.604.532 4.923.96c.757.245 1.477-.056 1.68-.631A7 7 0 0 0 8 3z"/>
+                </svg>
+                Dashboard
+            </a>
+
+            <!-- Users group -->
+            <div class="admin-sidebar__group-label">Users</div>
+
+            <a th:href="@{/admin/students}"
+               th:classappend="${currentUri.startsWith('/admin/students')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4zm-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.029 10 8 10c-2.029 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664h10z"/>
+                </svg>
+                Students
+            </a>
+
+            <a th:href="@{/admin/teachers}"
+               th:classappend="${currentUri.startsWith('/admin/teachers')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M6 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-5 6s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H1zM11 3.5a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1h-4a.5.5 0 0 1-.5-.5zm.5 2.5a.5.5 0 0 0 0 1h4a.5.5 0 0 0 0-1h-4zm2 3a.5.5 0 0 0 0 1h2a.5.5 0 0 0 0-1h-2zm0 3a.5.5 0 0 0 0 1h2a.5.5 0 0 0 0-1h-2z"/>
+                </svg>
+                Teachers
+            </a>
+
+            <a th:href="@{/admin/hods}"
+               th:classappend="${currentUri.startsWith('/admin/hods')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M3 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H3zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/>
+                    <path fill-rule="evenodd" d="M13 8a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 0 1H14v1.5a.5.5 0 0 1-1 0V8z"/>
+                </svg>
+                HODs
+            </a>
+
+            <a th:href="@{/admin/inactive-users}"
+               th:classappend="${currentUri.startsWith('/admin/inactive-users')} ? ' is-active'"
+               class="admin-sidebar__link admin-sidebar__link--warn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M11 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0ZM8 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm.256 7a4.474 4.474 0 0 1-.229-1.004H3c.001-.246.154-.986.832-1.664C4.484 10.68 5.896 10 8 10c.347 0 .681.019 1.004.054.227-.238.48-.46.757-.664C9.283 9.136 8.679 9 8 9c-5 0-6 3.5-6 4s1 1 1 1h5.256Zm3.63-4.54c.18-.613 1.048-.613 1.229 0l.043.148a.64.64 0 0 0 .921.382l.136-.074c.561-.306 1.175.308.87.869l-.075.136a.64.64 0 0 0 .382.92l.149.045c.612.18.612 1.048 0 1.229l-.15.043a.64.64 0 0 0-.38.921l.074.136c.305.561-.309 1.175-.87.87l-.136-.075a.64.64 0 0 0-.92.382l-.045.149c-.18.612-1.048.612-1.229 0l-.043-.15a.64.64 0 0 0-.921-.38l-.136.074c-.561.305-1.175-.309-.87-.87l.075-.136a.64.64 0 0 0-.382-.92l-.148-.045c-.613-.18-.613-1.048 0-1.229l.148-.043a.64.64 0 0 0 .382-.921l-.074-.136c-.306-.561.308-1.175.869-.87l.136.075a.64.64 0 0 0 .92-.382l.045-.148ZM14 12.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0Z"/>
+                </svg>
+                Inactive Users
+            </a>
+
+            <!-- Academic group -->
+            <div class="admin-sidebar__group-label">Academic</div>
+
+            <a th:href="@{/admin/departments}"
+               th:classappend="${currentUri.startsWith('/admin/departments') or currentUri.startsWith('/admin/add-department') or currentUri.startsWith('/admin/editDepartment') or currentUri.startsWith('/admin/assign-hod') or currentUri.startsWith('/admin/save-hod') or currentUri.startsWith('/admin/save-department')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M1 2.5A1.5 1.5 0 0 1 2.5 1h11A1.5 1.5 0 0 1 15 2.5v2.764c0 .408-.21.807-.523 1.029L9 9.05v6.95a.5.5 0 0 1-.724.447l-3-1.5A.5.5 0 0 1 5 14.5V9.05L1.523 6.293A1.25 1.25 0 0 1 1 5.264V2.5zM2.5 2a.5.5 0 0 0-.5.5v2.764a.25.25 0 0 0 .104.206l4.896 3.264V14l2 1V8.734l4.896-3.264A.25.25 0 0 0 14 5.264V2.5a.5.5 0 0 0-.5-.5h-11z"/>
+                </svg>
+                Departments
+            </a>
+
+            <a th:href="@{/admin/semesters}"
+               th:classappend="${currentUri.startsWith('/admin/semesters') or currentUri.startsWith('/admin/add-semester') or currentUri.startsWith('/admin/editSemester') or currentUri.startsWith('/admin/save-semester')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
+                </svg>
+                Semesters
+            </a>
+
+            <a th:href="@{/admin/courses}"
+               th:classappend="${currentUri.startsWith('/admin/courses')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M3 0h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-1h1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v1H1V2a2 2 0 0 1 2-2z"/>
+                    <path d="M1 5v-.5a.5.5 0 0 1 1 0V5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1H1zm0 3v-.5a.5.5 0 0 1 1 0V8h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1H1zm0 3v-.5a.5.5 0 0 1 1 0v.5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1H1z"/>
+                </svg>
+                Courses
+            </a>
+
+            <!-- Files -->
+            <div class="admin-sidebar__divider"></div>
+
+            <a th:href="@{/admin/files}"
+               th:classappend="${currentUri.startsWith('/admin/files')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5L14 4.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5h-2z"/>
+                </svg>
+                Files
+            </a>
+
+        </nav>
+
+        <!-- Logout -->
+        <div class="admin-sidebar__foot">
+            <form th:action="@{/logout}" method="POST">
+                <button type="submit" class="admin-sidebar__logout">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0v2z"/>
+                        <path fill-rule="evenodd" d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z"/>
+                    </svg>
+                    Logout
+                </button>
+            </form>
+        </div>
+
+    </aside>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Replaces the top dropdown navigation bar with a persistent fixed sidebar on desktop screens and a Bootstrap off-canvas drawer activated by a hamburger button on mobile and tablet screens
- Introduced `sidebar.html` as a shared Thymeleaf fragment with grouped navigation links (Users, Academic, Files), inline SVG icons, and active-link highlighting driven by a `currentUri` model attribute
- Extended `GlobalModelAttributes` to expose the current request URI, replacing the Thymeleaf 3.1 removed `#request` utility object
- Migrated all thirteen admin templates from the old navbar fragment to the new sidebar fragment with the required layout containers
- Applied responsive table improvements to the student, teacher, and HOD list pages

## Test Plan

- [ ] Log in as `admin1` on a desktop viewport — fixed sidebar is visible on the left with the correct active link highlighted
- [ ] Log in on a mobile viewport (< 992px) — hamburger button appears in the topbar; tapping it opens the off-canvas drawer
- [ ] Navigate to each admin page (Students, Teachers, HODs, Departments, Semesters, Courses, Files, Inactive Users) and verify the correct sidebar link is highlighted
- [ ] Verify the Logout button in the sidebar footer works correctly
- [ ] Verify the footer copyright year renders correctly on all pages