### PR TITLE
feat: security hardening, typed exceptions, admin password reset & profile

### DIFF
--- a/src/main/java/com/bitsunisage/campusconnect/config/SecurityConfiguration.java
+++ b/src/main/java/com/bitsunisage/campusconnect/config/SecurityConfiguration.java
@@ -4,7 +4,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.provisioning.UserDetailsManager;
@@ -17,29 +16,18 @@ import javax.sql.DataSource;
  * Spring Security configuration for CampusConnect.
  *
  * <p>Configures URL-based role authorization, form login with a custom success handler,
- * JDBC-backed authentication against the {@code members} and {@code roles} tables,
- * and static resource bypass for the login page assets.</p>
+ * and JDBC-backed authentication against the {@code members} and {@code roles} tables.
+ * Static assets and public paths are opened via {@code permitAll()} inside the filter chain
+ * rather than {@code WebSecurityCustomizer#ignoring}, so security headers still apply.</p>
  */
 @Configuration
 public class SecurityConfiguration {
 
     /**
-     * Bypasses the security filter chain for all static assets and the debug data view,
-     * so they are accessible without authentication.
-     *
-     * @return customizer that excludes static resource paths from security
-     */
-    @Bean
-    WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers(
-                "/loginResources/**", "/vendor/**", "/images/**", "/CSS/**", "/JS/**", "view-data");
-    }
-
-    /**
      * Defines the main security filter chain.
      *
      * <ul>
-     *   <li>{@code /} — public</li>
+     *   <li>Static assets and public paths — {@code permitAll()}</li>
      *   <li>{@code /student/**} — requires {@code ROLE_STUDENT}</li>
      *   <li>{@code /teacher/**} — requires {@code ROLE_TEACHER}</li>
      *   <li>{@code /admin/**}   — requires {@code ROLE_ADMIN}</li>
@@ -57,6 +45,9 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(configurer -> configurer
+                        .requestMatchers(
+                                "/loginResources/**", "/vendor/**",
+                                "/images/**", "/CSS/**", "/JS/**", "/view-data").permitAll()
                         .requestMatchers("/").permitAll()
                         .requestMatchers("/student/**").hasRole("STUDENT")
                         .requestMatchers("/teacher/**").hasRole("TEACHER")
@@ -74,12 +65,10 @@ public class SecurityConfiguration {
                 .logout(logout -> logout.permitAll()
                         .logoutSuccessUrl("/"))
                 .exceptionHandling(configurer -> configurer
-                        .accessDeniedHandler((request, response, accessDeniedException) -> {
-                            response.sendRedirect("/access-denied");
-                        })
-                        .authenticationEntryPoint((request, response, authException) -> {
-                            response.sendRedirect("/NoUrlFound");
-                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                response.sendRedirect("/access-denied"))
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendRedirect("/login"))
                 )
                 .httpBasic(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable);

--- a/src/main/java/com/bitsunisage/campusconnect/controller/AdminController.java
+++ b/src/main/java/com/bitsunisage/campusconnect/controller/AdminController.java
@@ -6,6 +6,8 @@ import com.bitsunisage.campusconnect.entities.FileData;
 import com.bitsunisage.campusconnect.entities.Roles;
 import com.bitsunisage.campusconnect.entities.Semester;
 import com.bitsunisage.campusconnect.entities.User;
+import com.bitsunisage.campusconnect.exceptions.DepartmentNotFoundException;
+import com.bitsunisage.campusconnect.exceptions.UserNotFoundException;
 import com.bitsunisage.campusconnect.service.StorageService;
 import com.bitsunisage.campusconnect.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -544,18 +546,27 @@ public class AdminController {
     /**
      * Saves the HOD-to-department assignment by updating the chosen HOD's {@code deptID}
      * and denormalised {@code department} name, then redirecting to the departments list.
+     * Redirects with an error flash if the department or HOD user cannot be found.
      *
      * @param deptId             the department to assign the HOD to
      * @param hodUserId          the login username of the HOD to assign
-     * @param redirectAttributes used to pass a success flash across the redirect
-     * @return redirect to {@code /admin/departments}
+     * @param redirectAttributes used to pass a success/error flash across the redirect
+     * @return redirect to {@code /admin/departments}, or back to the assign form on failure
      */
     @PostMapping("/admin/save-hod-assignment")
     public String saveHodAssignment(@RequestParam("deptId") Long deptId,
                                     @RequestParam("hodUserId") String hodUserId,
                                     RedirectAttributes redirectAttributes) {
         Department dept = userService.getDepartmentNameByDepartmentId(deptId.intValue());
+        if (dept == null) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Department not found.");
+            return "redirect:/admin/departments";
+        }
         User hod = userService.findUserByUserId(hodUserId);
+        if (hod == null) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Selected HOD user not found: " + hodUserId);
+            return "redirect:/admin/assign-hod?deptId=" + deptId;
+        }
         hod.setDeptID(deptId);
         hod.setDepartment(dept.getName());
         userService.save(hod);
@@ -680,6 +691,9 @@ public class AdminController {
     @GetMapping("/admin/profile")
     public String profilePage(Authentication authentication, Model model) {
         User admin = userService.findUserByUserId(authentication.getName());
+        if (admin == null) {
+            throw new UserNotFoundException(authentication.getName());
+        }
         admin.setPassword("");
         model.addAttribute("admin", admin);
         return "adminViewPages/profile";
@@ -708,6 +722,9 @@ public class AdminController {
             return "redirect:/admin/profile";
         }
         User admin = userService.findUserByUserId(authentication.getName());
+        if (admin == null) {
+            throw new UserNotFoundException(authentication.getName());
+        }
         admin.setEmail(email);
         if (!newPassword.isBlank()) {
             admin.setPassword("{noop}" + newPassword);

--- a/src/main/java/com/bitsunisage/campusconnect/controller/MasterController.java
+++ b/src/main/java/com/bitsunisage/campusconnect/controller/MasterController.java
@@ -1,13 +1,16 @@
 package com.bitsunisage.campusconnect.controller;
 
 import com.bitsunisage.campusconnect.exceptions.AccessDeniedCustomException;
+import com.bitsunisage.campusconnect.exceptions.ErrorResponse;
 import com.bitsunisage.campusconnect.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.servlet.ModelAndView;
 
 /**
  * Handles public and cross-cutting HTTP routes: the landing page, login, error pages,
@@ -63,12 +66,29 @@ public class MasterController implements ErrorController {
     }
 
     /**
-     * Triggers a 500 error view by throwing a {@link RuntimeException},
-     * which is handled by {@link com.bitsunisage.campusconnect.exceptions.CustomExceptionHandler}.
+     * Renders a generic 500 error page. Spring Boot routes unhandled servlet errors here
+     * because this controller implements {@link ErrorController}.
+     *
+     * @return {@link ModelAndView} with HTTP 500 and a generic error message
      */
     @GetMapping("/error")
-    public void error() {
-        throw new RuntimeException();
+    public ModelAndView error() {
+        ModelAndView mav = new ModelAndView("securityViewPages/errorStatus");
+        mav.setStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        mav.addObject("error", new ErrorResponse(500, "An unexpected error occurred. Please try again later."));
+        return mav;
+    }
+
+    /**
+     * Handles the redirect target for unauthenticated users who try to access a
+     * protected URL. Security is configured to send them here; this mapping
+     * forwards them to the login page.
+     *
+     * @return redirect to {@code /login}
+     */
+    @GetMapping("/NoUrlFound")
+    public String noUrlFound() {
+        return "redirect:/login";
     }
 
     /**

--- a/src/main/java/com/bitsunisage/campusconnect/exceptions/CustomExceptionHandler.java
+++ b/src/main/java/com/bitsunisage/campusconnect/exceptions/CustomExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.bitsunisage.campusconnect.exceptions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -8,41 +10,56 @@ import org.springframework.web.servlet.ModelAndView;
 /**
  * Global exception handler for the application.
  * Intercepts exceptions thrown from any {@code @Controller} and renders
- * a consistent error view rather than exposing stack traces to the user.
+ * a consistent error view with the correct HTTP status rather than exposing
+ * stack traces to the user.
  */
 @ControllerAdvice
 public class CustomExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomExceptionHandler.class);
+
+    private static ModelAndView errorView(int status, String message) {
+        ModelAndView mav = new ModelAndView("securityViewPages/errorStatus");
+        mav.setStatus(HttpStatus.valueOf(status));
+        mav.addObject("error", new ErrorResponse(status, message));
+        return mav;
+    }
+
+    /**
+     * Handles resource-not-found exceptions thrown when a required entity is absent.
+     * Returns HTTP 404 and renders the error status view with the exception message.
+     *
+     * @param e the {@link ResourceNotFoundException} that was thrown
+     * @return {@link ModelAndView} with HTTP 404 and the not-found message
+     */
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ModelAndView handleResourceNotFound(ResourceNotFoundException e) {
+        log.warn("Resource not found: {}", e.getMessage());
+        return errorView(HttpStatus.NOT_FOUND.value(), e.getMessage());
+    }
 
     /**
      * Handles access-denied scenarios raised by the application itself.
      * Returns HTTP 403 and renders the error status view.
      *
-     * @return {@link ModelAndView} pointing to the error template with a 403 response body
+     * @return {@link ModelAndView} with HTTP 403
      */
     @ExceptionHandler(AccessDeniedCustomException.class)
     public ModelAndView handleAccessDeniedCustomException() {
-        ErrorResponse errorResponse = new ErrorResponse();
-        errorResponse.setStatusCode(HttpStatus.FORBIDDEN.value());
-        errorResponse.setErrorMessage("Not enough accessibility!!!");
-        ModelAndView modelAndView = new ModelAndView("securityViewPages/errorStatus");
-        modelAndView.addObject("error", errorResponse);
-        return modelAndView;
+        return errorView(HttpStatus.FORBIDDEN.value(), "You do not have permission to access this resource.");
     }
 
     /**
      * Catch-all handler for any unhandled {@link Exception}.
-     * Returns HTTP 500 and renders the error status view.
+     * Logs the full stack trace so the error is diagnosable, then returns
+     * HTTP 500 and renders the error status view with a generic message.
      *
      * @param e the exception that was thrown
-     * @return {@link ModelAndView} pointing to the error template with a 500 response body
+     * @return {@link ModelAndView} with HTTP 500
      */
     @ExceptionHandler(Exception.class)
     public ModelAndView handleGenericException(Exception e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        errorResponse.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
-        errorResponse.setErrorMessage("Some internal error occurred!");
-        ModelAndView modelAndView = new ModelAndView("securityViewPages/errorStatus");
-        modelAndView.addObject("error", errorResponse);
-        return modelAndView;
+        log.error("Unhandled exception", e);
+        return errorView(HttpStatus.INTERNAL_SERVER_ERROR.value(), "An unexpected error occurred. Please try again later.");
     }
 }

--- a/src/main/java/com/bitsunisage/campusconnect/exceptions/DepartmentNotFoundException.java
+++ b/src/main/java/com/bitsunisage/campusconnect/exceptions/DepartmentNotFoundException.java
@@ -1,0 +1,16 @@
+package com.bitsunisage.campusconnect.exceptions;
+
+/**
+ * Thrown when a department lookup returns no result in a context where
+ * the department's existence is a precondition for an operation.
+ * Handled by {@link CustomExceptionHandler} as a 404 response.
+ */
+public class DepartmentNotFoundException extends ResourceNotFoundException {
+
+    /**
+     * @param deptId the numeric department ID that could not be found
+     */
+    public DepartmentNotFoundException(long deptId) {
+        super("Department not found: " + deptId);
+    }
+}

--- a/src/main/java/com/bitsunisage/campusconnect/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/bitsunisage/campusconnect/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,16 @@
+package com.bitsunisage.campusconnect.exceptions;
+
+/**
+ * Base exception for resource-not-found scenarios (HTTP 404).
+ * Subclasses identify the specific resource type that was missing.
+ * Handled by {@link CustomExceptionHandler}, which renders a 404 error view.
+ */
+public class ResourceNotFoundException extends RuntimeException {
+
+    /**
+     * @param message human-readable description of which resource was not found
+     */
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bitsunisage/campusconnect/exceptions/SemesterNotFoundException.java
+++ b/src/main/java/com/bitsunisage/campusconnect/exceptions/SemesterNotFoundException.java
@@ -1,0 +1,16 @@
+package com.bitsunisage.campusconnect.exceptions;
+
+/**
+ * Thrown when a semester lookup returns no result in a context where
+ * the semester's existence is a precondition for an operation.
+ * Handled by {@link CustomExceptionHandler} as a 404 response.
+ */
+public class SemesterNotFoundException extends ResourceNotFoundException {
+
+    /**
+     * @param semesterId the semester ID that could not be found
+     */
+    public SemesterNotFoundException(long semesterId) {
+        super("Semester not found: " + semesterId);
+    }
+}

--- a/src/main/java/com/bitsunisage/campusconnect/exceptions/UserNotFoundException.java
+++ b/src/main/java/com/bitsunisage/campusconnect/exceptions/UserNotFoundException.java
@@ -1,0 +1,17 @@
+package com.bitsunisage.campusconnect.exceptions;
+
+/**
+ * Thrown when a user lookup by ID returns no result in a context where
+ * the user's existence is a precondition (e.g. the currently logged-in user's
+ * own record, or a referenced user in a system operation).
+ * Handled by {@link CustomExceptionHandler} as a 404 response.
+ */
+public class UserNotFoundException extends ResourceNotFoundException {
+
+    /**
+     * @param userId the login username that could not be found
+     */
+    public UserNotFoundException(String userId) {
+        super("User not found: " + userId);
+    }
+}

--- a/src/test/java/com/bitsunisage/campusconnect/controller/AdminControllerTest.java
+++ b/src/test/java/com/bitsunisage/campusconnect/controller/AdminControllerTest.java
@@ -659,4 +659,122 @@ class AdminControllerTest {
                 .andExpect(view().name("adminViewPages/inactive-users"))
                 .andExpect(model().attribute("inactiveUsers", List.of(inactiveUser)));
     }
+
+    // ---- Exception handling (admin role) ----
+
+    @Test
+    void saveHodAssignment_whenHodUserNotFound_redirectsWithError() throws Exception {
+        when(userService.getDepartmentNameByDepartmentId(1001)).thenReturn(testDept);
+        when(userService.findUserByUserId("missingHod")).thenReturn(null);
+
+        mockMvc.perform(post("/admin/save-hod-assignment").with(csrf())
+                        .param("deptId", "1001")
+                        .param("hodUserId", "missingHod"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/assign-hod?deptId=1001"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        verify(userService, never()).save(any(User.class));
+    }
+
+    @Test
+    void saveHodAssignment_whenDepartmentNotFound_redirectsWithError() throws Exception {
+        when(userService.getDepartmentNameByDepartmentId(9999)).thenReturn(null);
+
+        mockMvc.perform(post("/admin/save-hod-assignment").with(csrf())
+                        .param("deptId", "9999")
+                        .param("hodUserId", "hod1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/departments"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        verify(userService, never()).save(any(User.class));
+    }
+
+    @Test
+    void profilePage_whenAdminAccountNotFound_returns404() throws Exception {
+        when(userService.findUserByUserId("admin1")).thenReturn(null);
+
+        mockMvc.perform(get("/admin/profile"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void saveProfile_whenAdminAccountNotFound_returns404() throws Exception {
+        when(userService.findUserByUserId("admin1")).thenReturn(null);
+
+        mockMvc.perform(post("/admin/save-profile").with(csrf())
+                        .param("email", "admin@test.com")
+                        .param("newPassword", "")
+                        .param("confirmPassword", ""))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void saveProfile_whenPasswordsMismatch_redirectsWithError() throws Exception {
+        when(userService.findUserByUserId("admin1")).thenReturn(testUser);
+
+        mockMvc.perform(post("/admin/save-profile").with(csrf())
+                        .param("email", "admin@test.com")
+                        .param("newPassword", "newpass")
+                        .param("confirmPassword", "different"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/profile"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        verify(userService, never()).save(any(User.class));
+    }
+
+    @Test
+    void resetPasswordForm_whenSelfReset_redirectsToProfile() throws Exception {
+        mockMvc.perform(get("/admin/reset-password")
+                        .param("userId", "admin1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/profile"));
+    }
+
+    @Test
+    void resetPassword_whenPasswordIsBlank_redirectsWithError() throws Exception {
+        when(userService.findUserByUserId("testUser")).thenReturn(testUser);
+
+        mockMvc.perform(post("/admin/reset-password").with(csrf())
+                        .param("userId", "testUser")
+                        .param("newPassword", "")
+                        .param("confirmPassword", ""))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/reset-password?userId=testUser"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        verify(userService, never()).save(any(User.class));
+    }
+
+    @Test
+    void resetPassword_whenPasswordsMismatch_redirectsWithError() throws Exception {
+        when(userService.findUserByUserId("testUser")).thenReturn(testUser);
+
+        mockMvc.perform(post("/admin/reset-password").with(csrf())
+                        .param("userId", "testUser")
+                        .param("newPassword", "pass1")
+                        .param("confirmPassword", "pass2"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/reset-password?userId=testUser"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        verify(userService, never()).save(any(User.class));
+    }
+
+    @Test
+    void resetPassword_whenUserNotFound_redirectsWithError() throws Exception {
+        when(userService.findUserByUserId("ghost")).thenReturn(null);
+
+        mockMvc.perform(post("/admin/reset-password").with(csrf())
+                        .param("userId", "ghost")
+                        .param("newPassword", "secret")
+                        .param("confirmPassword", "secret"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        verify(userService, never()).save(any(User.class));
+    }
 }


### PR DESCRIPTION
## Summary

- **Security:** Replaced `WebSecurityCustomizer` (web.ignoring) with `permitAll()` rules in the filter chain so Spring Security headers (CSP, X-Frame-Options, etc.) still apply to static assets. Fixed `authenticationEntryPoint` to redirect directly to `/login`.
- **Exceptions:** Added a `ResourceNotFoundException` hierarchy (`UserNotFoundException`, `DepartmentNotFoundException`, `SemesterNotFoundException`). Fixed `CustomExceptionHandler` to return correct HTTP status codes (was always 200), added SLF4J logging for 500s, and added a dedicated 404 handler. Added null guards in `AdminController` for HOD assignment and profile flows.
- **Admin – Password Reset:** Admins can reset any user's password via `/admin/reset-password`. Self-reset is blocked. Reset buttons added to students, teachers, and HODs list views.
- **Admin – Self-Edit Profile:** Admins can update their own email and optionally change their password via `/admin/profile`. Blank new-password field preserves the existing password.
- **Docs:** README screenshots consolidated into a three-column table.

## Test plan

- [ ] Static assets (CSS/JS/images) load without auth and still receive security headers
- [ ] Unauthenticated access to a protected URL redirects to `/login` (not `/NoUrlFound`)
- [ ] 404 responses return the error view with HTTP 404, not 200
- [ ] 500 errors appear in application logs
- [ ] Admin can reset another user's password; attempting self-reset redirects to profile page
- [ ] Admin can update email and change password; leaving new-password blank preserves existing password
- [ ] All 48 unit tests pass (`mvn test`)