### PR TITLE
feat(hod): full HOD UI refactor, theme system, and security fixes

### DIFF
--- a/src/main/java/com/bitsunisage/campusconnect/config/SecurityConfiguration.java
+++ b/src/main/java/com/bitsunisage/campusconnect/config/SecurityConfiguration.java
@@ -2,7 +2,10 @@ package com.bitsunisage.campusconnect.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
@@ -87,20 +90,41 @@ public class SecurityConfiguration {
     }
 
     /**
+     * Exposes the application-wide {@link AuthenticationManager} as a bean so it
+     * can be injected into {@link JdbcUserDetailsManager} for password re-authentication.
+     *
+     * @param config the {@link AuthenticationConfiguration} provided by Spring Boot
+     * @return the configured {@link AuthenticationManager}
+     * @throws Exception if the manager cannot be built
+     */
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    /**
      * Configures JDBC-backed authentication against the application's custom schema.
      * Custom queries map Spring Security's expected column names to the actual
      * {@code members} and {@code roles} table columns.
      *
-     * @param dataSource the application {@link DataSource} injected by Spring Boot
+     * <p>{@code @Lazy} on the {@link AuthenticationManager} parameter breaks the
+     * circular dependency: {@link JdbcUserDetailsManager} is a {@code UserDetailsService}
+     * used by the {@link AuthenticationManager}, while also needing it for
+     * password re-authentication.</p>
+     *
+     * @param dataSource            the application {@link DataSource} injected by Spring Boot
+     * @param authenticationManager the {@link AuthenticationManager} for re-auth on password change
      * @return a configured {@link UserDetailsManager}
      */
     @Bean
-    public UserDetailsManager userDetailsManager(DataSource dataSource) {
+    public UserDetailsManager userDetailsManager(DataSource dataSource,
+                                                 @Lazy AuthenticationManager authenticationManager) {
         JdbcUserDetailsManager jdbcUserDetailsManager = new JdbcUserDetailsManager(dataSource);
         jdbcUserDetailsManager.setUsersByUsernameQuery(
                 "SELECT user_id, pw, active FROM members WHERE user_id=?");
         jdbcUserDetailsManager.setAuthoritiesByUsernameQuery(
                 "SELECT user_id, role FROM roles WHERE user_id=?");
+        jdbcUserDetailsManager.setAuthenticationManager(authenticationManager);
         return jdbcUserDetailsManager;
     }
 }

--- a/src/main/java/com/bitsunisage/campusconnect/exceptions/CustomExceptionHandler.java
+++ b/src/main/java/com/bitsunisage/campusconnect/exceptions/CustomExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 /**
  * Global exception handler for the application.
@@ -47,6 +48,19 @@ public class CustomExceptionHandler {
     @ExceptionHandler(AccessDeniedCustomException.class)
     public ModelAndView handleAccessDeniedCustomException() {
         return errorView(HttpStatus.FORBIDDEN.value(), "You do not have permission to access this resource.");
+    }
+
+    /**
+     * Handles missing static resources (e.g. browser favicon.ico auto-requests).
+     * Returns HTTP 404 without logging a stack trace, since these are routine misses.
+     *
+     * @param e the {@link NoResourceFoundException} that was thrown
+     * @return {@link ModelAndView} with HTTP 404
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ModelAndView handleNoStaticResource(NoResourceFoundException e) {
+        log.debug("Static resource not found: {}", e.getResourcePath());
+        return errorView(HttpStatus.NOT_FOUND.value(), "Resource not found.");
     }
 
     /**

--- a/src/main/resources/static/CSS/HOD/add-course.css
+++ b/src/main/resources/static/CSS/HOD/add-course.css
@@ -1,6 +1,6 @@
 body {
     font-family: Arial, sans-serif;
-    background-color: #f4f4f4;
+    background-color: var(--clr-bg);
     margin: 0;
     padding: 0;
     display: flex;
@@ -10,10 +10,10 @@ body {
 }
 
 .container {
-    background-color: white;
+    background-color: var(--clr-surface);
     padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     max-width: 500px;
     width: 100%;
 }
@@ -21,7 +21,7 @@ body {
 h1 {
     text-align: center;
     margin-bottom: 20px;
-    color: #333;
+    color: var(--clr-text);
 }
 
 .form-group {
@@ -31,32 +31,33 @@ h1 {
 label {
     display: block;
     margin-bottom: 5px;
-    color: #555;
+    color: var(--clr-text-muted);
 }
 
 input[type="text"], input[type="number"], select, textarea {
     width: 100%;
     padding: 10px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+    border: 1px solid var(--clr-border);
+    border-radius: var(--radius-sm);
     box-sizing: border-box;
 }
 
 input[type="text"]:focus, input[type="number"]:focus, select:focus, textarea:focus {
-    border-color: #007bff;
+    border-color: var(--clr-primary);
     outline: none;
+    box-shadow: 0 0 0 3px var(--clr-primary-focus);
 }
 
 button {
     width: 100%;
     padding: 10px;
-    background-color: #007bff;
-    color: white;
+    background-color: var(--clr-primary);
+    color: var(--clr-text-white);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
 }
 
 button:hover {
-    background-color: #0056b3;
+    background-color: var(--clr-primary-dark);
 }

--- a/src/main/resources/static/CSS/HOD/main.css
+++ b/src/main/resources/static/CSS/HOD/main.css
@@ -2,163 +2,47 @@
 body {
     margin: 0;
     font-family: 'Roboto', sans-serif;
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
-    overflow: hidden;
-    background-color: #F5CBA7; /* Light yellow/gold background */
+    background-color: var(--clr-bg);
 }
 
 .custom-navbar {
-    background-color: #800020; /* Navbar background color */
+    background-color: var(--clr-primary);
 }
 
 .search-input {
-    color: black;
+    color: var(--clr-text);
     width: 150px;
 }
 
 .search-btn {
-    color: white;
+    color: var(--clr-text-white);
 }
 
 .custom-link, .notification-link {
-    color: white;
+    color: var(--clr-text-white);
     text-decoration: none;
 }
+
 .navbar-logo {
-    width: 150px; /* Adjust this value to the desired width */
-    /*height: auto; !* Keeps the aspect ratio of the logo *!*/
+    width: 150px;
 }
 
-
-.main-content {
-    padding: 20px;
-    height: calc(100vh - 60px); /* Adjusted to be below the header */
-    overflow-y: auto;
-    overflow-x: hidden;
-    box-sizing: border-box;
-    margin-left: 250px;
-    margin-top: 60px; /* Moved content below the header */
-    background-color: #F5CBA7; /* Soft peach background color */
-}
-
-.stats-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 20px;
-    width: 100%;
-    padding-top: 20px; /* Space below the fixed header */
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.stats-box {
-    height: 150px;
-    background-color: white;
-    border: 1px solid black;
-    color: black;
-    border-radius: 10px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    transition: transform 0.3s, box-shadow 0.3s;
-    margin-bottom: 20px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    cursor: pointer;
-}
-
-.stats-box:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
-}
-
-.stats-box h3, .stats-box h4 {
-    margin: 0;
-    color: black;
-}
-
-.stats-box h3 {
-    font-size: 2.5em;
-}
-
-.stats-box h4 {
-    font-size: 1.2em;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-}
-
-.stats-box h4 img {
-    width: 28px;
-    height: 28px;
-}
-
-.action-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 20px;
-    margin-top: 20px;
-}
-
-.action-buttons a {
-    text-decoration: none;
-    color: white;
-}
-
-.action-button {
-    background-color: #800020; /* Match navbar color */
-    color: white;
-    border: none;
-    padding: 15px 30px;
-    font-size: 16px;
-    border-radius: 5px;
-    cursor: pointer;
-    transition: background-color 0.3s;
-}
-
-.action-button:hover {
-    background-color: #6D1B35; /* Darker red for hover */
-}
-
-/* Style for the stats box text */
-.stats-box tbody tr td {
-    font-size: 1.2em;
-    font-weight: bold;
-    color: #800020; /* Match navbar color */
-    background-color: #F5CBA7; /* Match main-content background */
-    padding: 8px;
-    border-radius: 5px;
-    text-align: center;
-    width: 100%;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    transition: transform 0.3s, background-color 0.3s;
-}
-
-/* Hover effect to make the text interactive */
-.stats-box tbody tr td:hover {
-    background-color: #F4D03F; /* Slightly darker yellow on hover */
-    transform: translateY(-2px);
-}
 
 .no-pointer {
     cursor: default;
 }
 
 .navbar-nav .nav-link:hover {
-    color: #FFD700; /* Gold color on hover */
+    color: var(--clr-primary-light);
     text-decoration: underline;
 }
 
 .dropdown-menu {
-    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
-    border: 1px solid #B56576;
+    box-shadow: var(--shadow-md);
+    border: 1px solid var(--clr-border);
 }
 
 .navbar-nav .nav-link.active {
-    background-color: #6D1B35;
-    border-bottom: 2px solid #FFD700; /* Gold bottom border */
+    background-color: var(--clr-primary-dark);
+    border-bottom: 2px solid var(--clr-primary-light);
 }
-
-

--- a/src/main/resources/static/CSS/HOD/manage-course.css
+++ b/src/main/resources/static/CSS/HOD/manage-course.css
@@ -1,6 +1,6 @@
 body {
     font-family: Arial, sans-serif;
-    background-color: #f4f4f4;
+    background-color: var(--clr-bg);
     margin: 0;
     padding: 0;
     display: flex;
@@ -10,10 +10,10 @@ body {
 }
 
 .container {
-    background-color: white;
+    background-color: var(--clr-surface);
     padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
     max-width: 500px;
     width: 100%;
 }
@@ -21,7 +21,7 @@ body {
 h1 {
     text-align: center;
     margin-bottom: 20px;
-    color: #333;
+    color: var(--clr-text);
 }
 
 .form-group {
@@ -31,41 +31,42 @@ h1 {
 label {
     display: block;
     margin-bottom: 5px;
-    color: #555;
+    color: var(--clr-text-muted);
 }
 
 input[type="text"], input[type="number"], select, textarea {
     width: 100%;
     padding: 10px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+    border: 1px solid var(--clr-border);
+    border-radius: var(--radius-sm);
     box-sizing: border-box;
 }
 
 input[type="text"]:focus, input[type="number"]:focus, select:focus, textarea:focus {
-    border-color: #007bff;
+    border-color: var(--clr-primary);
     outline: none;
+    box-shadow: 0 0 0 3px var(--clr-primary-focus);
 }
 
 button {
     width: 100%;
     padding: 10px;
-    background-color: #007bff;
-    color: white;
+    background-color: var(--clr-primary);
+    color: var(--clr-text-white);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     margin-top: 10px;
 }
 
 button:hover {
-    background-color: #0056b3;
+    background-color: var(--clr-primary-dark);
 }
 
 button.btn-danger {
-    background-color: #dc3545;
+    background-color: var(--clr-danger);
 }
 
 button.btn-danger:hover {
-    background-color: #c82333;
+    background-color: var(--clr-danger-dark);
 }

--- a/src/main/resources/static/CSS/admin/main.css
+++ b/src/main/resources/static/CSS/admin/main.css
@@ -1,47 +1,3 @@
-:root {
-    /* Brand */
-    --clr-primary:        #007a7a;
-    --clr-primary-dark:   #005d5d;
-    --clr-primary-light:  #d6e6e6;
-    --clr-primary-mid:    #b4d3d3;
-    --clr-primary-focus:  rgba(0, 122, 122, 0.25);
-
-    /* Semantic */
-    --clr-danger:         #dc3545;
-    --clr-danger-dark:    #b02a37;
-    --clr-success:        #198754;
-    --clr-warning:        #f59e0b;
-
-    /* Surfaces */
-    --clr-bg:             #f5f7fa;
-    --clr-surface:        #ffffff;
-    --clr-border:         #dee2e6;
-
-    /* Text */
-    --clr-text:           #212529;
-    --clr-text-muted:     #6c757d;
-    --clr-text-white:     #ffffff;
-
-    /* Shape */
-    --radius-sm:          4px;
-    --radius-md:          8px;
-    --radius-lg:          12px;
-
-    /* Elevation */
-    --shadow-sm:          0 2px 4px rgba(0, 0, 0, 0.08);
-    --shadow-md:          0 4px 8px rgba(0, 0, 0, 0.10);
-    --shadow-lg:          0 6px 12px rgba(0, 0, 0, 0.20);
-
-    /* Motion */
-    --transition-base:    0.3s ease;
-
-    /* Sidebar */
-    --sidebar-w:          240px;
-    --sidebar-bg:         #0f1f1f;
-    --sidebar-border:     rgba(255, 255, 255, 0.07);
-    --topbar-h:           56px;
-}
-
 /* ── Base ───────────────────────────────────────────────────── */
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -235,7 +191,7 @@ body {
 
 .admin-sidebar__link.is-active {
     background: rgba(0, 122, 122, 0.18);
-    color: #ffffff;
+    color: var(--clr-text-white);
     border-left-color: var(--clr-primary);
     font-weight: 600;
 }
@@ -252,9 +208,9 @@ body {
 
 .admin-sidebar__link--warn:hover,
 .admin-sidebar__link--warn.is-active {
-    color: #f59e0b;
+    color: var(--clr-warning);
     background: rgba(245, 158, 11, 0.1);
-    border-left-color: #f59e0b;
+    border-left-color: var(--clr-warning);
 }
 
 .admin-sidebar__divider {
@@ -369,14 +325,14 @@ body {
 
 /* Colour variants */
 .stat-card--primary  { border-left-color: var(--clr-primary); }
-.stat-card--warning  { border-left-color: #f59e0b; }
+.stat-card--warning  { border-left-color: var(--clr-warning); }
 .stat-card--success  { border-left-color: var(--clr-success); }
-.stat-card--secondary { border-left-color: #6c757d; }
+.stat-card--secondary { border-left-color: var(--clr-text-muted); }
 
 .stat-card--primary  .stat-card__num { color: var(--clr-primary); }
-.stat-card--warning  .stat-card__num { color: #f59e0b; }
+.stat-card--warning  .stat-card__num { color: var(--clr-warning); }
 .stat-card--success  .stat-card__num { color: var(--clr-success); }
-.stat-card--secondary .stat-card__num { color: #6c757d; }
+.stat-card--secondary .stat-card__num { color: var(--clr-text-muted); }
 
 /* ── Activity feed ──────────────────────────────────────────── */
 
@@ -517,7 +473,7 @@ body {
 }
 
 .action-card--files:hover {
-    border-top-color: #146c43;
+    border-top-color: var(--clr-success-dark);
 }
 
 .action-card__icon {

--- a/src/main/resources/static/CSS/security/main.css
+++ b/src/main/resources/static/CSS/security/main.css
@@ -1,6 +1,6 @@
 body {
     font-family: Arial, sans-serif;
-    background-color: #f4f4f4;
+    background-color: var(--clr-bg);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -10,10 +10,10 @@ body {
 
 .access-denied-container {
     text-align: center;
-    background-color: white;
+    background-color: var(--clr-surface);
     padding: 40px;
-    border-radius: 8px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
 }
 
 .access-denied-image {
@@ -23,13 +23,13 @@ body {
 
 .access-denied-title {
     font-size: 36px;
-    color: #333;
+    color: var(--clr-text);
     margin-top: 20px;
 }
 
 .access-denied-message {
     font-size: 18px;
-    color: #666;
+    color: var(--clr-text-muted);
     margin-top: 10px;
 }
 
@@ -37,14 +37,14 @@ body {
     display: inline-block;
     margin-top: 30px;
     padding: 10px 20px;
-    background-color: #007bff;
-    color: white;
+    background-color: var(--clr-primary);
+    color: var(--clr-text-white);
     text-decoration: none;
-    border-radius: 5px;
+    border-radius: var(--radius-sm);
     font-size: 16px;
-    transition: background-color 0.3s ease;
+    transition: background-color var(--transition-base);
 }
 
 .home-button:hover {
-    background-color: #0056b3;
+    background-color: var(--clr-primary-dark);
 }

--- a/src/main/resources/static/CSS/theme.css
+++ b/src/main/resources/static/CSS/theme.css
@@ -1,0 +1,176 @@
+/* ═══════════════════════════════════════════════════════════════════
+   CampusConnect — Master Theme
+   Single source of truth for all design tokens.
+
+   Usage: add this <link> BEFORE any role-specific stylesheet in every
+   Thymeleaf template:
+     <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+
+   Role CSS files may override individual tokens in their own :root
+   blocks if the role genuinely needs a different value. Everything
+   else should use the variables defined here.
+   ═══════════════════════════════════════════════════════════════════ */
+
+
+/* ── Light mode (default) ───────────────────────────────────────── */
+
+:root {
+
+    /* ── Brand — teal palette ─────────────────────────────────── */
+    --clr-primary:        #007a7a;
+    --clr-primary-dark:   #005d5d;
+    --clr-primary-mid:    #006666;
+    --clr-primary-light:  #d6e6e6;
+    --clr-primary-focus:  rgba(0, 122, 122, 0.25);
+
+    /* ── Semantic feedback ────────────────────────────────────── */
+    --clr-danger:         #dc3545;
+    --clr-danger-dark:    #b02a37;
+    --clr-success:        #198754;
+    --clr-success-dark:   #146c43;
+    --clr-warning:        #f59e0b;
+    --clr-warning-dark:   #d97706;
+
+    /* ── Surfaces ─────────────────────────────────────────────── */
+    --clr-bg:             #f5f7fa;
+    --clr-surface:        #ffffff;
+    --clr-border:         #dee2e6;
+
+    /* ── Text ─────────────────────────────────────────────────── */
+    --clr-text:           #1a2a2a;   /* teal-tinted dark, on-brand */
+    --clr-text-muted:     #5a6e6e;   /* teal-tinted grey */
+    --clr-text-white:     #ffffff;
+
+    /* ── Dark surfaces (sidebar, navbar, footer) ──────────────── */
+    --clr-dark-nav:       #122020;
+    --clr-dark-sidebar:   #0f1f1f;
+    --clr-dark-footer:    #0d1a1a;
+    --clr-dark-border:    rgba(255, 255, 255, 0.07);
+
+    /* ── Gradient palette (hero, section backgrounds) ─────────── */
+    --clr-gradient-start: #003d3d;
+    --clr-gradient-mid:   #006060;
+    --clr-gradient-end:   #007a7a;
+    --clr-accent-light:   #7fe8e8;   /* hero title accent */
+
+    /* ── Shape ────────────────────────────────────────────────── */
+    --radius-sm:          4px;
+    --radius-md:          8px;
+    --radius-lg:          12px;
+    --radius-xl:          20px;
+    --radius-pill:        999px;
+
+    /* ── Elevation ────────────────────────────────────────────── */
+    --shadow-sm:          0 2px 4px  rgba(0, 0, 0, 0.08);
+    --shadow-md:          0 4px 8px  rgba(0, 0, 0, 0.10);
+    --shadow-lg:          0 6px 12px rgba(0, 0, 0, 0.20);
+    --shadow-xl:          0 16px 48px rgba(0, 0, 0, 0.22);
+
+    /* ── Motion ───────────────────────────────────────────────── */
+    --transition-base:    0.3s ease;
+
+    /* ── Layout shell (shared by all role dashboards) ─────────── */
+    --sidebar-w:          240px;
+    --sidebar-bg:         var(--clr-dark-sidebar);
+    --sidebar-border:     var(--clr-dark-border);
+    --topbar-h:           56px;
+}
+
+
+/* ── Dark mode — reserved for future toggle implementation ──────── */
+/*
+   Not yet active. Will be enabled by a JS toggle that sets
+   data-theme="dark" on the <html> element. All variables below
+   override the light-mode defaults. Role-specific CSS does NOT
+   need to redeclare dark-mode values unless a component behaves
+   differently from these base tokens.
+*/
+[data-theme="dark"] {
+
+    /* Surfaces */
+    --clr-bg:             #0d1a1a;
+    --clr-surface:        #122020;
+    --clr-border:         #1e3030;
+
+    /* Text */
+    --clr-text:           #e0ecec;
+    --clr-text-muted:     #8aadad;
+
+    /* Brand — keeps the same primary but adjusts supporting tones */
+    --clr-primary-light:  #1a3535;
+    --clr-primary-focus:  rgba(0, 122, 122, 0.35);
+
+    /* Semantic — slightly muted on dark backgrounds */
+    --clr-danger:         #f87171;
+    --clr-success:        #4ade80;
+    --clr-warning:        #fbbf24;
+
+    /* Dark surfaces become slightly lighter on dark backgrounds */
+    --clr-dark-nav:       #0a1515;
+    --clr-dark-sidebar:   #091414;
+    --clr-dark-footer:    #060e0e;
+}
+
+
+/* ── Base reset ─────────────────────────────────────────────────── */
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: var(--clr-bg);
+    color: var(--clr-text);
+    font-size: 1rem;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+}
+
+
+/* ── Bootstrap primary colour overrides ────────────────────────── */
+/*
+   Keeps Bootstrap component colours (buttons, inputs, focus rings)
+   aligned with the teal brand palette without touching Bootstrap
+   source or adding a custom build step.
+*/
+
+.btn-primary {
+    background-color: var(--clr-primary);
+    border-color:     var(--clr-primary);
+}
+
+.btn-primary:hover,
+.btn-primary:active,
+.btn-primary:focus-visible {
+    background-color: var(--clr-primary-dark);
+    border-color:     var(--clr-primary-dark);
+}
+
+.btn-primary:focus-visible {
+    box-shadow: 0 0 0 0.2rem var(--clr-primary-focus);
+}
+
+.btn-outline-primary {
+    color:        var(--clr-primary);
+    border-color: var(--clr-primary);
+}
+
+.btn-outline-primary:hover {
+    background-color: var(--clr-primary);
+    border-color:     var(--clr-primary);
+    color:            var(--clr-text-white);
+}
+
+.form-control:focus,
+.form-select:focus {
+    border-color: var(--clr-primary);
+    box-shadow:   0 0 0 0.2rem var(--clr-primary-focus);
+}
+
+.form-control[readonly] {
+    background-color: var(--clr-bg);
+    color:            var(--clr-text-muted);
+    cursor:           not-allowed;
+}

--- a/src/main/resources/static/loginResources/CSS/homepage.css
+++ b/src/main/resources/static/loginResources/CSS/homepage.css
@@ -1,23 +1,5 @@
 :root {
-    --clr-primary:        #007a7a;
-    --clr-primary-dark:   #005d5d;
-    --clr-primary-mid:    #006666;
-    --clr-primary-light:  #d6e6e6;
-    --clr-bg:             #f5f7fa;
-    --clr-surface:        #ffffff;
-    --clr-border:         #dee2e6;
-    --clr-text:           #1a2a2a;
-    --clr-text-muted:     #5a6e6e;
-    --clr-text-white:     #ffffff;
-    --radius-sm:          4px;
-    --radius-md:          8px;
-    --radius-lg:          14px;
-    --radius-xl:          20px;
-    --shadow-sm:          0 2px 6px rgba(0, 0, 0, 0.07);
-    --shadow-md:          0 6px 16px rgba(0, 0, 0, 0.11);
-    --shadow-lg:          0 12px 32px rgba(0, 0, 0, 0.15);
-    --transition-base:    0.28s ease;
-    --nav-h:              68px;
+    --nav-h: 68px;
 }
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -161,7 +143,7 @@ body {
     top: 0;
     z-index: 200;
     height: var(--nav-h);
-    background: #122020;
+    background: var(--clr-dark-nav);
     border-bottom: 2px solid var(--clr-primary);
     backdrop-filter: blur(4px);
 }
@@ -233,7 +215,7 @@ body {
     position: relative;
     overflow: hidden;
     min-height: calc(100vh - var(--nav-h));
-    background: linear-gradient(145deg, #003d3d 0%, #006060 40%, #007a7a 75%, #009898 100%);
+    background: linear-gradient(145deg, var(--clr-gradient-start) 0%, var(--clr-gradient-mid) 40%, var(--clr-primary) 75%, #009898 100%);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -302,7 +284,7 @@ body {
 }
 
 .lp-hero__title-accent {
-    color: #7fe8e8;
+    color: var(--clr-accent-light);
 }
 
 .lp-hero__sub {
@@ -620,7 +602,7 @@ body {
    ────────────────────────────────────────────────────────── */
 
 .lp-contact {
-    background: linear-gradient(145deg, #003d3d 0%, #006060 50%, #007a7a 100%);
+    background: linear-gradient(145deg, var(--clr-gradient-start) 0%, var(--clr-gradient-mid) 50%, var(--clr-primary) 100%);
     padding: 5.5rem 1.5rem;
     text-align: center;
 }
@@ -667,7 +649,7 @@ body {
    ────────────────────────────────────────────────────────── */
 
 .lp-footer {
-    background: #0d1a1a;
+    background: var(--clr-dark-footer);
     color: rgba(255, 255, 255, 0.45);
     padding: 2rem 1.5rem;
     border-top: 1px solid #1e3030;

--- a/src/main/resources/static/loginResources/CSS/main.css
+++ b/src/main/resources/static/loginResources/CSS/main.css
@@ -1,22 +1,3 @@
-:root {
-    --clr-primary:       #007a7a;
-    --clr-primary-dark:  #005d5d;
-    --clr-primary-light: #d6e6e6;
-    --clr-primary-focus: rgba(0, 122, 122, 0.22);
-    --clr-bg:            #f5f7fa;
-    --clr-surface:       #ffffff;
-    --clr-border:        #dee2e6;
-    --clr-text:          #1a2a2a;
-    --clr-text-muted:    #5a6e6e;
-    --clr-text-white:    #ffffff;
-    --clr-danger:        #dc3545;
-    --radius-sm:         4px;
-    --radius-md:         8px;
-    --radius-lg:         14px;
-    --shadow-lg:         0 16px 48px rgba(0, 0, 0, 0.22);
-    --transition-base:   0.25s ease;
-}
-
 *, *::before, *::after { box-sizing: border-box; }
 
 body {
@@ -29,7 +10,7 @@ body {
 
 .login-bg {
     min-height: 100vh;
-    background: linear-gradient(145deg, #003d3d 0%, #006060 50%, #009494 100%);
+    background: linear-gradient(145deg, var(--clr-gradient-start) 0%, var(--clr-gradient-mid) 50%, #009494 100%);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/main/resources/templates/ReferralData.html
+++ b/src/main/resources/templates/ReferralData.html
@@ -5,33 +5,34 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Campus Connect Data</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" th:href="@{/CSS/theme.css}">
   <style>
     body {
-      background-color: #f8f9fa;
+      background-color: var(--clr-bg);
       font-family: Arial, sans-serif;
     }
     .container {
       margin-top: 50px;
     }
     h1 {
-      color: #5a5c69;
+      color: var(--clr-text-muted);
       font-weight: bold;
       text-align: center;
       margin-bottom: 40px;
     }
     .card {
       margin: 20px 0;
-      border-radius: 10px;
+      border-radius: var(--radius-lg);
     }
     .card-header {
-      background-color: #007bff;
-      color: white;
+      background-color: var(--clr-primary);
+      color: var(--clr-text-white);
       font-weight: bold;
       text-align: center;
     }
     .table thead {
-      background-color: #007bff;
-      color: white;
+      background-color: var(--clr-primary);
+      color: var(--clr-text-white);
     }
   </style>
 </head>

--- a/src/main/resources/templates/adminViewPages/add-department.html
+++ b/src/main/resources/templates/adminViewPages/add-department.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <title th:text="${dept.id != null} ? 'Edit Department' : 'Add Department'">Add Department</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/userAddForm.css}">
 </head>

--- a/src/main/resources/templates/adminViewPages/add-semester.html
+++ b/src/main/resources/templates/adminViewPages/add-semester.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <title th:text="${semester.semesterId != null} ? 'Edit Semester' : 'Add Semester'">Add Semester</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/userAddForm.css}">
 </head>

--- a/src/main/resources/templates/adminViewPages/add-user.html
+++ b/src/main/resources/templates/adminViewPages/add-user.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <title th:text="${user.userId != null and !#strings.isEmpty(user.userId)} ? 'Edit User' : 'Add User'">Add User</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/userAddForm.css}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet"/>

--- a/src/main/resources/templates/adminViewPages/admin.html
+++ b/src/main/resources/templates/adminViewPages/admin.html
@@ -5,6 +5,7 @@
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <title>Admin Dashboard &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/adminViewPages/assign-hod.html
+++ b/src/main/resources/templates/adminViewPages/assign-hod.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <title th:text="'Assign HOD — ' + ${dept.name}">Assign HOD</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/adminViewPages/courses.html
+++ b/src/main/resources/templates/adminViewPages/courses.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <title>Courses &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/adminViewPages/departments.html
+++ b/src/main/resources/templates/adminViewPages/departments.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <title>Departments &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/adminViewPages/files.html
+++ b/src/main/resources/templates/adminViewPages/files.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <title>Files &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/adminViewPages/gethod.html
+++ b/src/main/resources/templates/adminViewPages/gethod.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <title>HODs &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/adminViewPages/getstudents.html
+++ b/src/main/resources/templates/adminViewPages/getstudents.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <title>Students &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/adminViewPages/getteachers.html
+++ b/src/main/resources/templates/adminViewPages/getteachers.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <title>Teachers &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/adminViewPages/inactive-users.html
+++ b/src/main/resources/templates/adminViewPages/inactive-users.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <title>Inactive Users &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/adminViewPages/profile.html
+++ b/src/main/resources/templates/adminViewPages/profile.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <title>Profile &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/userAddForm.css}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet"/>

--- a/src/main/resources/templates/adminViewPages/reset-password.html
+++ b/src/main/resources/templates/adminViewPages/reset-password.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <title>Reset Password &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/userAddForm.css}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet"/>

--- a/src/main/resources/templates/adminViewPages/semesters.html
+++ b/src/main/resources/templates/adminViewPages/semesters.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <title>Semesters &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/hodViewPages/add-course.html
+++ b/src/main/resources/templates/hodViewPages/add-course.html
@@ -2,31 +2,50 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
-    <title>Add Course</title>
+    <title>Add Course &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
-    <link rel="stylesheet" th:href="@{/CSS/HOD/add-course.css}">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
+    <link rel="stylesheet" th:href="@{/CSS/admin/userAddForm.css}">
 </head>
 <body>
-<div th:replace="~{hodViewPages/hodnavbar :: navbar}"></div>
-<div class="container mt-5" style="max-width: 600px;">
-    <h2 class="mb-4">Add New Course</h2>
-    <form th:action="@{/hod/save-course}" method="post">
-        <div class="mb-3">
-            <label class="form-label fw-semibold">Department</label>
-            <input type="text" class="form-control" th:value="${department}" readonly>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
+
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
+    <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6">
+            <div class="form-card">
+                <div class="form-card-title">Add New Course</div>
+
+                <form th:action="@{/hod/save-course}" method="post">
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Department</label>
+                        <input type="text" class="form-control" th:value="${department}" readonly>
+                    </div>
+                    <div class="mb-4">
+                        <label for="courseName" class="form-label fw-semibold">Course Name</label>
+                        <input type="text" id="courseName" name="courseName" class="form-control"
+                               placeholder="e.g. Bachelor of Computer Applications" required>
+                    </div>
+                    <div class="d-flex gap-2 flex-wrap">
+                        <button type="submit" class="btn btn-primary">Save Course</button>
+                        <a th:href="@{/hod/manage-course}" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
         </div>
-        <div class="mb-3">
-            <label for="courseName" class="form-label fw-semibold">Course Name</label>
-            <input type="text" id="courseName" name="courseName" class="form-control"
-                   placeholder="e.g. Bachelor of Computer Applications" required>
-        </div>
-        <div class="d-flex gap-2">
-            <button type="submit" class="btn btn-primary">Save Course</button>
-            <a th:href="@{/hod/manage-course}" class="btn btn-outline-secondary">Cancel</a>
-        </div>
-    </form>
+    </div>
+
 </div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/hodViewPages/add-subject.html
+++ b/src/main/resources/templates/hodViewPages/add-subject.html
@@ -2,49 +2,71 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
-    <title>Add Subject</title>
+    <title>Add Subject &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
+    <link rel="stylesheet" th:href="@{/CSS/admin/userAddForm.css}">
 </head>
 <body>
-<div th:replace="~{hodViewPages/hodnavbar :: navbar}"></div>
-<div class="container mt-5" style="max-width: 600px;">
-    <h2 class="mb-4">Add New Subject</h2>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
 
-    <div th:if="${courses.empty}" class="alert alert-warning">
-        No courses found for your department. <a th:href="@{/hod/add-course}">Add a course first.</a>
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
+    <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6">
+
+            <div th:if="${courses.empty}" class="alert alert-warning">
+                No courses found for your department.
+                <a th:href="@{/hod/add-course}">Add a course first.</a>
+            </div>
+
+            <div th:unless="${courses.empty}" class="form-card">
+                <div class="form-card-title">Add New Subject</div>
+
+                <form th:action="@{/hod/save-subject}" method="post">
+                    <div class="mb-3">
+                        <label for="courseId" class="form-label fw-semibold">Course</label>
+                        <select id="courseId" name="courseId" class="form-select" required>
+                            <option value="" disabled selected>Select a course</option>
+                            <option th:each="course : ${courses}"
+                                    th:value="${course.courseId}"
+                                    th:text="${course.courseName}"></option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="semesterId" class="form-label fw-semibold">Semester</label>
+                        <select id="semesterId" name="semesterId" class="form-select" required>
+                            <option value="" disabled selected>Select a semester</option>
+                            <option th:each="sem : ${semesters}"
+                                    th:value="${sem.semesterId}"
+                                    th:text="${sem.semesterName}"></option>
+                        </select>
+                    </div>
+                    <div class="mb-4">
+                        <label for="subjectName" class="form-label fw-semibold">Subject Name</label>
+                        <input type="text" id="subjectName" name="subjectName" class="form-control"
+                               placeholder="e.g. Data Structures and Algorithms" required>
+                    </div>
+                    <div class="d-flex gap-2 flex-wrap">
+                        <button type="submit" class="btn btn-primary">Save Subject</button>
+                        <a th:href="@{/hod/manage-subject}" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+
+        </div>
     </div>
 
-    <form th:unless="${courses.empty}" th:action="@{/hod/save-subject}" method="post">
-        <div class="mb-3">
-            <label for="courseId" class="form-label fw-semibold">Course</label>
-            <select id="courseId" name="courseId" class="form-select" required>
-                <option value="" disabled selected>Select a course</option>
-                <option th:each="course : ${courses}"
-                        th:value="${course.courseId}"
-                        th:text="${course.courseName}"></option>
-            </select>
-        </div>
-        <div class="mb-3">
-            <label for="semesterId" class="form-label fw-semibold">Semester</label>
-            <select id="semesterId" name="semesterId" class="form-select" required>
-                <option value="" disabled selected>Select a semester</option>
-                <option th:each="sem : ${semesters}"
-                        th:value="${sem.semesterId}"
-                        th:text="${sem.semesterName}"></option>
-            </select>
-        </div>
-        <div class="mb-3">
-            <label for="subjectName" class="form-label fw-semibold">Subject Name</label>
-            <input type="text" id="subjectName" name="subjectName" class="form-control"
-                   placeholder="e.g. Data Structures and Algorithms" required>
-        </div>
-        <div class="d-flex gap-2">
-            <button type="submit" class="btn btn-primary">Save Subject</button>
-            <a th:href="@{/hod/manage-subject}" class="btn btn-outline-secondary">Cancel</a>
-        </div>
-    </form>
 </div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/hodViewPages/curriculum.html
+++ b/src/main/resources/templates/hodViewPages/curriculum.html
@@ -2,18 +2,24 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <title th:text="${course.courseName} + ' — Curriculum'">Curriculum</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{hodViewPages/hodnavbar :: navbar}"></div>
-<div class="container mt-4">
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
 
-    <div class="d-flex justify-content-between align-items-center mb-4">
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-4">
         <div>
-            <h2 class="mb-0" th:text="${course.courseName}">Course Name</h2>
-            <small class="text-muted">Curriculum — one section per semester</small>
+            <h2 class="fw-semibold mb-0" style="color: var(--clr-text);" th:text="${course.courseName}">Course Name</h2>
+            <small class="text-muted">Curriculum &mdash; one section per semester</small>
         </div>
         <a th:href="@{/hod/manage-course}" class="btn btn-outline-secondary btn-sm">Back to Courses</a>
     </div>
@@ -24,39 +30,48 @@
     </div>
 
     <div th:each="sem : ${semesters}" class="mb-4">
-        <h5 class="border-bottom pb-1 mb-3" th:text="${sem.semesterName}">Semester I</h5>
+        <p class="section-label" th:text="${sem.semesterName}">Semester I</p>
 
-        <!-- Subjects already assigned to this course in this semester -->
         <th:block th:with="semSubjects=${subjectsBySemester[sem.semesterId]}">
-            <table th:unless="${semSubjects == null or semSubjects.empty}" class="table table-sm table-hover mb-2">
-                <thead class="table-light">
-                <tr>
-                    <th>#</th>
-                    <th>Subject</th>
-                    <th style="width:90px;"></th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="sub, stat : ${semSubjects}">
-                    <td th:text="${stat.count}" class="text-muted"></td>
-                    <td th:text="${sub.subjectName}"></td>
-                    <td>
-                        <form th:action="@{/hod/delete-subject}" method="post"
-                              th:data-name="${sub.subjectName}"
-                              onsubmit="return confirm('Remove ' + this.dataset.name + ' from this semester?')">
-                            <input type="hidden" name="subjectId" th:value="${sub.subjectId}">
-                            <input type="hidden" name="courseId" th:value="${course.courseId}">
-                            <button type="submit" class="btn btn-sm btn-outline-danger">Remove</button>
-                        </form>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-            <p th:if="${semSubjects == null or semSubjects.empty}" class="text-muted small ms-1">No subjects assigned yet.</p>
+
+            <!-- Subjects table for this semester -->
+            <div th:unless="${semSubjects == null or semSubjects.empty}"
+                 class="card shadow-sm mb-2" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
+                <div class="table-responsive">
+                    <table class="table table-hover table-sm mb-0 align-middle">
+                        <thead style="background-color: var(--clr-primary-light);">
+                        <tr>
+                            <th>#</th>
+                            <th>Subject</th>
+                            <th style="width:90px;"></th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr th:each="sub, stat : ${semSubjects}">
+                            <td th:text="${stat.count}" class="text-muted"></td>
+                            <td th:text="${sub.subjectName}"></td>
+                            <td>
+                                <form th:action="@{/hod/delete-subject}" method="post"
+                                      th:data-name="${sub.subjectName}"
+                                      onsubmit="return confirm('Remove ' + this.dataset.name + ' from this semester?')">
+                                    <input type="hidden" name="subjectId" th:value="${sub.subjectId}">
+                                    <input type="hidden" name="courseId" th:value="${course.courseId}">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">Remove</button>
+                                </form>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <p th:if="${semSubjects == null or semSubjects.empty}"
+               class="text-muted small ms-1 mb-2">No subjects assigned yet.</p>
+
         </th:block>
 
-        <!-- Inline add-subject form for this semester -->
-        <form th:action="@{/hod/save-subject}" method="post" class="d-flex gap-2 align-items-center">
+        <!-- Inline add-subject form -->
+        <form th:action="@{/hod/save-subject}" method="post" class="d-flex gap-2 align-items-center flex-wrap">
             <input type="hidden" name="courseId" th:value="${course.courseId}">
             <input type="hidden" name="semesterId" th:value="${sem.semesterId}">
             <input type="text" name="subjectName" class="form-control form-control-sm"
@@ -66,6 +81,10 @@
     </div>
 
 </div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/hodViewPages/hod.html
+++ b/src/main/resources/templates/hodViewPages/hod.html
@@ -2,79 +2,74 @@
 <html lang="en" xmlns:sec="http://www.thymeleaf.org/extras/spring-security" xmlns:th="http://www.thymeleaf.org/">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
-    <title>HOD Admin Page</title>
+    <title>HOD Dashboard &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
-    <link rel="stylesheet" th:href="@{/CSS/HOD/main.css}">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="hodViewPages/hodnavbar :: navbar"></div>
-<div class="main-content">
-    <div class="stats-container">
-        <table class="stats-box">
-            <thead>
-            <tr>
-                <td><h4><img th:src="@{SVGs/building-solid.svg}"> Department Name</h4></td>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td th:text="${departmentName}"></td>
-            </tr>
-            </tbody>
-        </table>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
 
-        <table class="stats-box">
-            <thead>
-            <tr>
-                <td><h4><img th:src="@{SVGs/chalkboard-user-solid.svg}"> Total Faculty</h4></td>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td th:text="${totalFaculty}"></td>
-            </tr>
-            </tbody>
-        </table>
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
 
-        <table class="stats-box">
-            <thead>
-            <tr>
-                <td><h4><img th:src="@{SVGs/user-graduate-solid.svg}"> Total Students</h4></td>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td th:text="${totalStudents}"></td>
-            </tr>
-            </tbody>
-        </table>
-
-        <table class="stats-box">
-            <thead>
-            <tr>
-                <td><h4><img th:src="@{SVGs/gears-solid.svg}"> Total Courses</h4></td>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td th:text="${totalCourses}"></td>
-            </tr>
-            </tbody>
-        </table>
+    <!-- Welcome header -->
+    <div class="d-flex align-items-baseline justify-content-between flex-wrap gap-2 mb-3">
+        <h5 class="mb-0">Welcome, <strong sec:authentication="principal.username"></strong></h5>
+        <span class="text-muted" style="font-size:0.85rem;"
+              th:text="'Department: ' + ${departmentName}"></span>
     </div>
 
-    <div class="action-buttons">
-        <a class="text-white" th:href="@{/hod/add-course}">
-            <button class="action-button">Add Course</button>
+    <!-- Department overview -->
+    <p class="section-label">Department Overview</p>
+    <div class="stats-grid mb-4">
+        <div class="stat-card stat-card--primary">
+            <div class="stat-card__num" th:text="${totalFaculty}">0</div>
+            <div class="stat-card__label">Faculty</div>
+        </div>
+        <div class="stat-card stat-card--primary">
+            <div class="stat-card__num" th:text="${totalStudents}">0</div>
+            <div class="stat-card__label">Students</div>
+        </div>
+        <div class="stat-card stat-card--success">
+            <div class="stat-card__num" th:text="${totalCourses}">0</div>
+            <div class="stat-card__label">Courses</div>
+        </div>
+    </div>
+
+    <!-- Quick Actions -->
+    <p class="section-label">Quick Actions</p>
+    <div class="action-grid mb-4">
+        <a th:href="@{/hod/add-course}" class="action-card text-decoration-none">
+            <div class="action-card__icon">+</div>
+            <div class="action-card__title">Add Course</div>
+            <div class="action-card__desc">Register a new course for your department</div>
         </a>
-        <a class="text-white" th:href="@{/hod/manage-course}">
-            <button class="action-button">Manage Courses</button>
+        <a th:href="@{/hod/manage-course}" class="action-card text-decoration-none">
+            <div class="action-card__icon">&equiv;</div>
+            <div class="action-card__title">Manage Courses</div>
+            <div class="action-card__desc">Edit or remove existing department courses</div>
         </a>
-        <a class="text-white" th:href="@{/hod/manage-subject}">
-            <button class="action-button">Manage Subjects</button>
+        <a th:href="@{/hod/add-subject}" class="action-card text-decoration-none">
+            <div class="action-card__icon">+</div>
+            <div class="action-card__title">Add Subject</div>
+            <div class="action-card__desc">Add a subject to a course and semester</div>
+        </a>
+        <a th:href="@{/hod/manage-subject}" class="action-card action-card--files text-decoration-none">
+            <div class="action-card__icon">&equiv;</div>
+            <div class="action-card__title">Manage Subjects</div>
+            <div class="action-card__desc">Review and delete subject entries</div>
         </a>
     </div>
+
 </div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
+<script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/hodViewPages/hodnavbar.html
+++ b/src/main/resources/templates/hodViewPages/hodnavbar.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <div th:fragment="navbar">
-    <nav class="navbar navbar-expand-lg navbar-light custom-navbar">
+    <nav class="navbar navbar-expand-lg navbar-dark custom-navbar">
         <div class="container-fluid">
             <a class="navbar-brand" th:href="@{/hod}">
                 <img th:src="@{/loginResources/images/main-logo-white-transparent.png}" alt="Logo" class="navbar-logo">
@@ -21,7 +21,7 @@
                     <li class="nav-item d-flex align-items-center me-3">
                         <form class="d-flex" role="search">
                             <input class="form-control me-2 search-input" type="search" placeholder="Search" aria-label="Search">
-                            <button class="btn btn-outline-success search-btn" type="submit">
+                            <button class="btn btn-outline-light search-btn" type="submit">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
                                     <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85zm-5.442 1.032a5.5 5.5 0 1 1 7.778-7.778 5.5 5.5 0 0 1-7.778 7.778z"/>
                                 </svg>
@@ -44,7 +44,7 @@
 
                 </ul>
                 <form class="d-flex ms-auto">
-                    <a href="/notifications" class="d-flex align-items-center me-3 custom-link notification-link" style="margin-right: 30px; color: white;">
+                    <a href="/notifications" class="d-flex align-items-center me-3 custom-link notification-link" style="margin-right: 30px; color: var(--clr-text-white);">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
                             <path d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2zM8 1a4.5 4.5 0 0 0-4.5 4.5v3.086l-.823 2.469A1 1 0 0 0 3.616 13h8.768a1 1 0 0 0 .939-1.445l-.823-2.469V5.5A4.5 4.5 0 0 0 8 1zm.5 10.5a.5.5 0 0 1-1 0v-1a.5.5 0 0 1 1 0v1zM4 6.5a.5.5 0 0 1 1 0v2a.5.5 0 0 1-1 0v-2zm6 0a.5.5 0 0 1 1 0v2a.5.5 0 0 1-1 0v-2z"/>
                         </svg>

--- a/src/main/resources/templates/hodViewPages/hodsidebar.html
+++ b/src/main/resources/templates/hodViewPages/hodsidebar.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org/">
+<body>
+<div th:fragment="hodsidebar">
+
+    <!-- ── Mobile topbar (hidden on lg+) ──────────────────── -->
+    <nav class="admin-topbar d-flex d-lg-none align-items-center">
+        <button class="admin-topbar__toggle" type="button"
+                data-bs-toggle="offcanvas" data-bs-target="#hodSidebar"
+                aria-controls="hodSidebar" aria-label="Open navigation">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 16 16" fill="currentColor">
+                <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+            </svg>
+        </button>
+        <a class="admin-topbar__brand" th:href="@{/hod}">
+            <img th:src="@{/loginResources/images/main-logo-black-transparent.png}" alt="CampusConnect">
+            <span>HOD Panel</span>
+        </a>
+    </nav>
+
+    <!-- ── Sidebar (off-canvas on mobile, fixed on desktop) ── -->
+    <aside class="admin-sidebar offcanvas offcanvas-start"
+           tabindex="-1" id="hodSidebar" aria-labelledby="hodSidebarLabel">
+
+        <!-- Sidebar header -->
+        <div class="admin-sidebar__head">
+            <a class="admin-sidebar__brand" th:href="@{/hod}" id="hodSidebarLabel">
+                <img th:src="@{/loginResources/images/main-logo-white-transparent.png}" alt="CampusConnect">
+                <span>HOD Panel</span>
+            </a>
+            <button type="button" class="admin-sidebar__close d-lg-none"
+                    data-bs-dismiss="offcanvas" aria-label="Close">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854z"/>
+                </svg>
+            </button>
+        </div>
+
+        <!-- Navigation -->
+        <nav class="admin-sidebar__nav" aria-label="HOD navigation">
+
+            <!-- Dashboard -->
+            <a th:href="@{/hod}"
+               th:classappend="${currentUri == '/hod'} ? ' is-active'"
+               class="admin-sidebar__link admin-sidebar__link--dashboard">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M8 4a.5.5 0 0 1 .5.5V6a.5.5 0 0 1-1 0V4.5A.5.5 0 0 1 8 4zM3.732 5.732a.5.5 0 0 1 .707 0l.915.914a.5.5 0 1 1-.708.708l-.914-.915a.5.5 0 0 1 0-.707zM2 10a.5.5 0 0 1 .5-.5h1.586a.5.5 0 0 1 0 1H2.5A.5.5 0 0 1 2 10zm9.5 0a.5.5 0 0 1 .5-.5h1.5a.5.5 0 0 1 0 1H12a.5.5 0 0 1-.5-.5zm.754-4.246a.389.389 0 0 0-.527-.02L7.547 9.31a.91.91 0 1 0 1.302 1.258l3.434-4.297a.389.389 0 0 0-.029-.518z"/>
+                    <path fill-rule="evenodd" d="M0 10a8 8 0 1 1 15.547 2.661c-.442 1.253-1.845 1.602-2.932 1.25C11.309 13.488 9.475 13 8 13c-1.474 0-3.31.488-4.615.911-1.087.352-2.49.003-2.932-1.25A7.988 7.988 0 0 1 0 10zm8-7a7 7 0 0 0-6.603 9.329c.203.575.923.876 1.68.63C4.397 12.533 6.358 12 8 12s3.604.532 4.923.96c.757.245 1.477-.056 1.68-.631A7 7 0 0 0 8 3z"/>
+                </svg>
+                Dashboard
+            </a>
+
+            <!-- Academic group -->
+            <div class="admin-sidebar__group-label">Courses</div>
+
+            <a th:href="@{/hod/add-course}"
+               th:classappend="${currentUri.startsWith('/hod/add-course') or currentUri.startsWith('/hod/save-course')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2z"/>
+                </svg>
+                Add Course
+            </a>
+
+            <a th:href="@{/hod/manage-course}"
+               th:classappend="${currentUri.startsWith('/hod/manage-course') or currentUri.startsWith('/hod/update-course') or currentUri.startsWith('/hod/delete-course')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M3 0h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-1h1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v1H1V2a2 2 0 0 1 2-2z"/>
+                    <path d="M1 5v-.5a.5.5 0 0 1 1 0V5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1H1zm0 3v-.5a.5.5 0 0 1 1 0V8h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1H1zm0 3v-.5a.5.5 0 0 1 1 0v.5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1H1z"/>
+                </svg>
+                Manage Courses
+            </a>
+
+            <!-- Subjects group -->
+            <div class="admin-sidebar__group-label">Subjects</div>
+
+            <a th:href="@{/hod/add-subject}"
+               th:classappend="${currentUri.startsWith('/hod/add-subject') or currentUri.startsWith('/hod/save-subject')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2z"/>
+                </svg>
+                Add Subject
+            </a>
+
+            <a th:href="@{/hod/manage-subject}"
+               th:classappend="${currentUri.startsWith('/hod/manage-subject') or currentUri.startsWith('/hod/delete-subject')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M1 2.5A1.5 1.5 0 0 1 2.5 1h11A1.5 1.5 0 0 1 15 2.5v2.764c0 .408-.21.807-.523 1.029L9 9.05v6.95a.5.5 0 0 1-.724.447l-3-1.5A.5.5 0 0 1 5 14.5V9.05L1.523 6.293A1.25 1.25 0 0 1 1 5.264V2.5zM2.5 2a.5.5 0 0 0-.5.5v2.764a.25.25 0 0 0 .104.206l4.896 3.264V14l2 1V8.734l4.896-3.264A.25.25 0 0 0 14 5.264V2.5a.5.5 0 0 0-.5-.5h-11z"/>
+                </svg>
+                Manage Subjects
+            </a>
+
+            <!-- Divider -->
+            <div class="admin-sidebar__divider"></div>
+
+            <a th:href="@{/hod/curriculum}"
+               th:classappend="${currentUri.startsWith('/hod/curriculum')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5L14 4.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5h-2z"/>
+                </svg>
+                Curriculum
+            </a>
+
+            <!-- Account -->
+            <div class="admin-sidebar__divider"></div>
+
+            <a th:href="@{/hod/profile}"
+               th:classappend="${currentUri.startsWith('/hod/profile')} ? ' is-active'"
+               class="admin-sidebar__link">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4zm-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.029 10 8 10c-2.029 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664h10z"/>
+                </svg>
+                My Profile
+            </a>
+
+        </nav>
+
+        <!-- Logout -->
+        <div class="admin-sidebar__foot">
+            <form th:action="@{/logout}" method="POST">
+                <button type="submit" class="admin-sidebar__logout">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0v2z"/>
+                        <path fill-rule="evenodd" d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z"/>
+                    </svg>
+                    Logout
+                </button>
+            </form>
+        </div>
+
+    </aside>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/hodViewPages/manage-course.html
+++ b/src/main/resources/templates/hodViewPages/manage-course.html
@@ -2,62 +2,83 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
-    <title>Manage Courses</title>
+    <title>Manage Courses &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
-    <link rel="stylesheet" th:href="@{/CSS/HOD/manage-course.css}">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{hodViewPages/hodnavbar :: navbar}"></div>
-<div class="container mt-5">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>Manage Courses</h2>
-        <a th:href="@{/hod/add-course}" class="btn btn-primary">+ Add Course</a>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
+
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">Manage Courses</h2>
+        <a th:href="@{/hod/add-course}" class="btn btn-primary btn-sm">+ Add Course</a>
     </div>
 
-    <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
-
-    <div th:if="${courses.empty}" class="alert alert-info">
-        No courses found for your department. <a th:href="@{/hod/add-course}">Add one now.</a>
+    <div th:if="${errorMessage}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${errorMessage}"></span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
 
-    <table th:unless="${courses.empty}" class="table table-bordered table-hover">
-        <thead class="table-dark">
-        <tr>
-            <th>#</th>
-            <th>Course Name</th>
-            <th style="width: 260px;">Rename</th>
-            <th style="width: 120px;">Curriculum</th>
-            <th style="width: 100px;">Delete</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="course, stat : ${courses}">
-            <td th:text="${stat.count}"></td>
-            <td th:text="${course.courseName}"></td>
-            <td>
-                <form th:action="@{/hod/update-course}" method="post" class="d-flex gap-1">
-                    <input type="hidden" name="courseId" th:value="${course.courseId}">
-                    <input type="text" name="courseName" th:value="${course.courseName}"
-                           class="form-control form-control-sm" required>
-                    <button type="submit" class="btn btn-sm btn-success">Save</button>
-                </form>
-            </td>
-            <td>
-                <a class="btn btn-sm btn-outline-primary"
-                   th:href="@{/hod/curriculum(courseId=${course.courseId})}">Edit</a>
-            </td>
-            <td>
-                <form th:action="@{/hod/delete-course}" method="post"
-                      onsubmit="return confirm('Delete this course? This cannot be undone.');">
-                    <input type="hidden" name="courseId" th:value="${course.courseId}">
-                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
-                </form>
-            </td>
-        </tr>
-        </tbody>
-    </table>
+    <div th:if="${courses.empty}" class="text-center py-5" style="color: var(--clr-text-muted);">
+        No courses found for your department.
+        <a th:href="@{/hod/add-course}" class="d-block mt-2 btn btn-primary btn-sm" style="width:fit-content;margin:0.75rem auto 0;">Add your first course</a>
+    </div>
+
+    <div th:unless="${courses.empty}"
+         class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
+        <div class="table-responsive">
+            <table class="table table-hover mb-0 align-middle">
+                <thead style="background-color: var(--clr-primary-light);">
+                <tr>
+                    <th>#</th>
+                    <th>Course Name</th>
+                    <th style="min-width:240px;">Rename</th>
+                    <th>Curriculum</th>
+                    <th>Delete</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="course, stat : ${courses}">
+                    <td th:text="${stat.count}" class="text-muted"></td>
+                    <td th:text="${course.courseName}"></td>
+                    <td>
+                        <form th:action="@{/hod/update-course}" method="post" class="d-flex gap-1">
+                            <input type="hidden" name="courseId" th:value="${course.courseId}">
+                            <input type="text" name="courseName" th:value="${course.courseName}"
+                                   class="form-control form-control-sm" required>
+                            <button type="submit" class="btn btn-sm btn-success text-nowrap">Save</button>
+                        </form>
+                    </td>
+                    <td>
+                        <a class="btn btn-sm btn-outline-primary"
+                           th:href="@{/hod/curriculum(courseId=${course.courseId})}">Edit</a>
+                    </td>
+                    <td>
+                        <form th:action="@{/hod/delete-course}" method="post"
+                              th:data-name="${course.courseName}"
+                              onsubmit="return confirm('Delete ' + this.dataset.name + '? This cannot be undone.');">
+                            <input type="hidden" name="courseId" th:value="${course.courseId}">
+                            <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
 </div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/hodViewPages/manage-subject.html
+++ b/src/main/resources/templates/hodViewPages/manage-subject.html
@@ -2,76 +2,90 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
-    <title>Manage Subjects</title>
+    <title>Manage Subjects &mdash; CampusConnect</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/admin/main.css}">
 </head>
 <body>
-<div th:replace="~{hodViewPages/hodnavbar :: navbar}"></div>
-<div class="container mt-5">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>Manage Subjects</h2>
-        <a th:href="@{/hod/add-subject}" class="btn btn-primary">+ Add Subject</a>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
+
+<div class="admin-page-content">
+<main class="admin-main">
+<div class="admin-container">
+
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="fw-semibold mb-0" style="color: var(--clr-text);">Manage Subjects</h2>
+        <a th:href="@{/hod/add-subject}" class="btn btn-primary btn-sm">+ Add Subject</a>
     </div>
 
     <div th:if="${courses.empty}" class="alert alert-warning">
         No courses found. <a th:href="@{/hod/add-course}">Add a course first.</a>
     </div>
 
-    <form th:unless="${courses.empty}" th:action="@{/hod/manage-subject}" method="get" class="row g-2 mb-4">
-        <div class="col-auto">
-            <select name="courseId" class="form-select" required>
-                <option value="" disabled th:selected="${selectedCourseId == null}">Select a course</option>
-                <option th:each="course : ${courses}"
-                        th:value="${course.courseId}"
-                        th:text="${course.courseName}"
-                        th:selected="${course.courseId == selectedCourseId}"></option>
-            </select>
-        </div>
-        <div class="col-auto">
-            <button type="submit" class="btn btn-secondary">View Subjects</button>
-        </div>
+    <!-- Course filter -->
+    <form th:unless="${courses.empty}" th:action="@{/hod/manage-subject}" method="get"
+          class="d-flex gap-2 align-items-center mb-4 flex-wrap">
+        <select name="courseId" class="form-select" style="max-width:320px;" required>
+            <option value="" disabled th:selected="${selectedCourseId == null}">Select a course to view subjects</option>
+            <option th:each="course : ${courses}"
+                    th:value="${course.courseId}"
+                    th:text="${course.courseName}"
+                    th:selected="${course.courseId == selectedCourseId}"></option>
+        </select>
+        <button type="submit" class="btn btn-secondary">View Subjects</button>
     </form>
 
+    <!-- Subject tables grouped by semester -->
     <div th:if="${subjects != null}">
         <div th:if="${subjects.empty}" class="alert alert-info">
             No subjects yet for this course. <a th:href="@{/hod/add-subject}">Add one.</a>
         </div>
 
-        <!-- Group subjects by semester -->
         <div th:unless="${subjects.empty}" th:each="sem : ${semesters}">
             <th:block th:with="semSubjects=${subjectsBySemester[sem.semesterId]}">
                 <div th:unless="${semSubjects == null or semSubjects.empty}" class="mb-4">
-                    <h6 class="border-bottom pb-1 text-secondary" th:text="${sem.semesterName}">Semester</h6>
-                    <table class="table table-bordered table-hover table-sm">
-                        <thead class="table-dark">
-                        <tr>
-                            <th>#</th>
-                            <th>Subject Name</th>
-                            <th style="width:100px;"></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        <tr th:each="subject, stat : ${semSubjects}">
-                            <td th:text="${stat.count}"></td>
-                            <td th:text="${subject.subjectName}"></td>
-                            <td>
-                                <form th:action="@{/hod/delete-subject}" method="post"
-                                      th:data-name="${subject.subjectName}"
-                                      onsubmit="return confirm('Delete ' + this.dataset.name + '? This cannot be undone.')">
-                                    <input type="hidden" name="subjectId" th:value="${subject.subjectId}">
-                                    <input type="hidden" name="courseId" th:value="${selectedCourseId}">
-                                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
-                                </form>
-                            </td>
-                        </tr>
-                        </tbody>
-                    </table>
+                    <p class="section-label" th:text="${sem.semesterName}">Semester</p>
+                    <div class="card shadow-sm" style="border-radius: var(--radius-md); border-color: var(--clr-border);">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0 align-middle">
+                                <thead style="background-color: var(--clr-primary-light);">
+                                <tr>
+                                    <th>#</th>
+                                    <th>Subject Name</th>
+                                    <th style="width:100px;"></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr th:each="subject, stat : ${semSubjects}">
+                                    <td th:text="${stat.count}" class="text-muted"></td>
+                                    <td th:text="${subject.subjectName}"></td>
+                                    <td>
+                                        <form th:action="@{/hod/delete-subject}" method="post"
+                                              th:data-name="${subject.subjectName}"
+                                              onsubmit="return confirm('Delete ' + this.dataset.name + '? This cannot be undone.')">
+                                            <input type="hidden" name="subjectId" th:value="${subject.subjectId}">
+                                            <input type="hidden" name="courseId" th:value="${selectedCourseId}">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
             </th:block>
         </div>
     </div>
+
 </div>
+</main>
+<div th:replace="~{adminViewPages/footer :: footer}"></div>
+</div>
+
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+  <link rel="stylesheet" th:href="@{/CSS/theme.css}">
   <link rel="stylesheet" th:href="@{loginResources/CSS/home.css}">
   <link rel="icon" th:href="@{/images/main-logo-black-transparent.jpeg}" type="image/png">
 </head>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -6,6 +6,7 @@
     <title>CampusConnect &mdash; Collaborative Learning Platform</title>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/loginResources/CSS/homepage.css}">
 </head>
 <body>

--- a/src/main/resources/templates/loginFile.html
+++ b/src/main/resources/templates/loginFile.html
@@ -6,6 +6,7 @@
     <title>Sign In &mdash; CampusConnect</title>
     <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/loginResources/CSS/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/securityViewPages/errorStatus.html
+++ b/src/main/resources/templates/securityViewPages/errorStatus.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <title>Error | Campus Connect</title>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <link rel="stylesheet" th:href="@{/CSS/security/main.css}">
 </head>
 <body>

--- a/src/main/resources/templates/studentViewPages/PPTs.html
+++ b/src/main/resources/templates/studentViewPages/PPTs.html
@@ -5,20 +5,21 @@
   <title>Access PPTs</title>
   <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+  <link rel="stylesheet" th:href="@{/CSS/theme.css}">
   <style>
     body {
-      background-color: #f8f9fa;
+      background-color: var(--clr-bg);
     }
     .resources {
-      background: #ffffff;
-      border-radius: 8px;
-      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      background: var(--clr-surface);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-md);
       padding: 20px;
       margin: 20px auto;
-      max-width: 1000px; /* Increased max width for better table presentation */
+      max-width: 1000px;
     }
     h2 {
-      color: #333;
+      color: var(--clr-text);
       margin-bottom: 20px;
     }
     table {
@@ -26,8 +27,8 @@
       margin-top: 15px;
     }
     th {
-      background-color: #007bff;
-      color: white;
+      background-color: var(--clr-primary);
+      color: var(--clr-text-white);
       text-align: center;
     }
     td {

--- a/src/main/resources/templates/studentViewPages/indexstudent.html
+++ b/src/main/resources/templates/studentViewPages/indexstudent.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Title</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 </head>
 <style>
     .sidebar {
@@ -12,7 +13,7 @@
         top: 0;
         height: 100%;
         width: 200px;
-        background-color: #f8f9fa;
+        background-color: var(--clr-bg);
         padding-top: 60px;
         padding-left: 15px;
         padding-right: 15px;
@@ -51,22 +52,22 @@
             <h4 class="text-center">Available Resources</h4>
         </div>
         <div class="col-md-4 mb-3">
-            <a th:href="@{/student/PPTs}" class="btn btn-outline-success w-100">Access PPTs</a>
+            <a th:href="@{/student/PPTs}" class="btn btn-outline-primary w-100">Access PPTs</a>
         </div>
         <div class="col-md-4 mb-3">
-            <a th:href="@{/student/notes}" class="btn btn-outline-success w-100">Access Lecture Notes</a>
+            <a th:href="@{/student/notes}" class="btn btn-outline-primary w-100">Access Lecture Notes</a>
         </div>
         <div class="col-md-4 mb-3">
-            <a th:href="@{/student/programs}" class="btn btn-outline-success w-100">Access Sample Programs</a>
+            <a th:href="@{/student/programs}" class="btn btn-outline-primary w-100">Access Sample Programs</a>
         </div>
         <div class="col-md-4 mb-3">
-            <a th:href="@{/student/audiobooks}" class="btn btn-outline-success w-100">Access Audio Books</a>
+            <a th:href="@{/student/audiobooks}" class="btn btn-outline-primary w-100">Access Audio Books</a>
         </div>
         <div class="col-md-4 mb-3">
-            <a th:href="@{/student/referencebooks}" class="btn btn-outline-success w-100">Access Reference Books</a>
+            <a th:href="@{/student/referencebooks}" class="btn btn-outline-primary w-100">Access Reference Books</a>
         </div>
         <div class="col-md-4 mb-3">
-            <a th:href="@{/student/video}" class="btn btn-outline-success w-100">Access Video Tutorials</a>
+            <a th:href="@{/student/video}" class="btn btn-outline-primary w-100">Access Video Tutorials</a>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/studentViewPages/searchppts.html
+++ b/src/main/resources/templates/studentViewPages/searchppts.html
@@ -5,22 +5,23 @@
     <title>Resources</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <style>
         body {
             font-family: Arial, sans-serif;
             margin: 0;
             padding: 0;
-            background-color: #f8f9fa;
+            background-color: var(--clr-bg);
         }
 
         .container {
             max-width: 900px;
             margin: 50px auto;
             padding: 20px;
-            background-color: white;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--clr-surface);
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-md);
+            box-shadow: var(--shadow-sm);
         }
 
         .header {
@@ -51,14 +52,14 @@
         label {
             font-size: 14px;
             margin-bottom: 5px;
-            color: #333;
+            color: var(--clr-text);
         }
 
         select {
             height: 35px;
             padding: 5px 10px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-sm);
             font-size: 14px;
         }
 
@@ -73,22 +74,22 @@
         }
 
         th, td {
-            border: 1px solid #ddd;
+            border: 1px solid var(--clr-border);
             padding: 8px;
             text-align: left;
         }
 
         th {
-            background-color: #f2f2f2;
+            background-color: var(--clr-bg);
             font-weight: bold;
         }
 
         .btn {
             text-decoration: none;
             padding: 5px 10px;
-            color: white;
-            background-color: #007bff;
-            border-radius: 4px;
+            color: var(--clr-text-white);
+            background-color: var(--clr-primary);
+            border-radius: var(--radius-sm);
         }
 
         .btn i {

--- a/src/main/resources/templates/studentViewPages/video.html
+++ b/src/main/resources/templates/studentViewPages/video.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <title>Access PPTs</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 </head>
 <body>
 <div class ="container">

--- a/src/main/resources/templates/teacherViewPages/indexteacher.html
+++ b/src/main/resources/templates/teacherViewPages/indexteacher.html
@@ -5,6 +5,7 @@
     <title>Teacher's Dashboard - Upload Resources</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 
     <style>
         .sidebar {
@@ -13,7 +14,7 @@
             top: 0;
             height: 100%;
             width: 250px;
-            background-color: #f8f9fa;
+            background-color: var(--clr-bg);
             padding-top: 60px;
             padding-left: 15px;
             padding-right: 15px;

--- a/src/main/resources/templates/teacherViewPages/uploadNotes.html
+++ b/src/main/resources/templates/teacherViewPages/uploadNotes.html
@@ -10,23 +10,24 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 
     <style>
         body {
             font-family: Arial, sans-serif;
             margin: 0;
             padding: 0;
-            background-color: #f8f9fa;
+            background-color: var(--clr-bg);
         }
 
         .container {
             max-width: 900px;
             margin: 50px auto;
             padding: 20px;
-            background-color: white;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--clr-surface);
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-md);
+            box-shadow: var(--shadow-sm);
         }
 
         .header {
@@ -62,19 +63,19 @@
         label {
             font-size: 14px;
             margin-bottom: 5px;
-            color: #333;
+            color: var(--clr-text);
         }
 
         select {
             height: 35px;
             padding: 5px 10px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-sm);
             font-size: 14px;
         }
 
         .resources {
-            display: none; /* Hidden by default */
+            display: none;
             margin-top: 20px;
         }
 
@@ -90,9 +91,9 @@
             margin-left: 10px;
             text-decoration: none;
             padding: 5px 10px;
-            color: white;
-            background-color: #007bff;
-            border-radius: 4px;
+            color: var(--clr-text-white);
+            background-color: var(--clr-primary);
+            border-radius: var(--radius-sm);
         }
 
         .btn i {

--- a/src/main/resources/templates/teacherViewPages/uploadPPTs.html
+++ b/src/main/resources/templates/teacherViewPages/uploadPPTs.html
@@ -10,11 +10,12 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <!-- Font Awesome -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 
     <style>
         body {
             font-family: Arial, sans-serif;
-            background-color: #f8f9fa;
+            background-color: var(--clr-bg);
             margin: 0;
             padding: 0;
         }
@@ -23,10 +24,10 @@
             max-width: 900px;
             margin: 50px auto;
             padding: 20px;
-            background-color: white;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--clr-surface);
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-md);
+            box-shadow: var(--shadow-sm);
         }
 
         .header {
@@ -52,14 +53,14 @@
         label {
             font-size: 14px;
             margin-bottom: 5px;
-            color: #333;
+            color: var(--clr-text);
         }
 
         select, input[type="file"] {
             height: 35px;
             padding: 5px 10px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-sm);
             font-size: 14px;
             width: 100%;
         }
@@ -68,14 +69,14 @@
             margin-top: 20px;
             text-decoration: none;
             padding: 10px 20px;
-            color: white;
-            background-color: #007bff;
+            color: var(--clr-text-white);
+            background-color: var(--clr-primary);
             border: none;
-            border-radius: 4px;
+            border-radius: var(--radius-sm);
         }
 
         .btn:hover {
-            background-color: #0056b3;
+            background-color: var(--clr-primary-dark);
         }
     </style>
 </head>

--- a/src/main/resources/templates/teacherViewPages/uploadReferenceBooks.html
+++ b/src/main/resources/templates/teacherViewPages/uploadReferenceBooks.html
@@ -6,22 +6,23 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 <style>
     body {
         font-family: Arial, sans-serif;
         margin: 0;
         padding: 0;
-        background-color: #f8f9fa;
+        background-color: var(--clr-bg);
     }
 
     .container {
         max-width: 900px;
         margin: 50px auto;
         padding: 20px;
-        background-color: white;
-        border: 1px solid #ddd;
-        border-radius: 8px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        background-color: var(--clr-surface);
+        border: 1px solid var(--clr-border);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-sm);
     }
 
     .header {
@@ -57,19 +58,19 @@
     label {
         font-size: 14px;
         margin-bottom: 5px;
-        color: #333;
+        color: var(--clr-text);
     }
 
     select {
         height: 35px;
         padding: 5px 10px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
+        border: 1px solid var(--clr-border);
+        border-radius: var(--radius-sm);
         font-size: 14px;
     }
 
     .resources {
-        display: none; /* Hidden by default */
+        display: none;
         margin-top: 20px;
     }
 
@@ -85,9 +86,9 @@
         margin-left: 10px;
         text-decoration: none;
         padding: 5px 10px;
-        color: white;
-        background-color: #007bff;
-        border-radius: 4px;
+        color: var(--clr-text-white);
+        background-color: var(--clr-primary);
+        border-radius: var(--radius-sm);
     }
 
     .btn i {

--- a/src/main/resources/templates/teacherViewPages/uploadResult.html
+++ b/src/main/resources/templates/teacherViewPages/uploadResult.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Teacher's Dashboard - Upload Resources</title>
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 </head>
 
 <body>

--- a/src/main/resources/templates/teacherViewPages/uploadVideos.html
+++ b/src/main/resources/templates/teacherViewPages/uploadVideos.html
@@ -6,22 +6,23 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 <style>
     body {
         font-family: Arial, sans-serif;
         margin: 0;
         padding: 0;
-        background-color: #f8f9fa;
+        background-color: var(--clr-bg);
     }
 
     .container {
         max-width: 900px;
         margin: 50px auto;
         padding: 20px;
-        background-color: white;
-        border: 1px solid #ddd;
-        border-radius: 8px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        background-color: var(--clr-surface);
+        border: 1px solid var(--clr-border);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-sm);
     }
 
     .header {
@@ -57,19 +58,19 @@
     label {
         font-size: 14px;
         margin-bottom: 5px;
-        color: #333;
+        color: var(--clr-text);
     }
 
     select {
         height: 35px;
         padding: 5px 10px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
+        border: 1px solid var(--clr-border);
+        border-radius: var(--radius-sm);
         font-size: 14px;
     }
 
     .resources {
-        display: none; /* Hidden by default */
+        display: none;
         margin-top: 20px;
     }
 
@@ -85,9 +86,9 @@
         margin-left: 10px;
         text-decoration: none;
         padding: 5px 10px;
-        color: white;
-        background-color: #007bff;
-        border-radius: 4px;
+        color: var(--clr-text-white);
+        background-color: var(--clr-primary);
+        border-radius: var(--radius-sm);
     }
 
     .btn i {

--- a/src/main/resources/templates/teacherViewPages/uploadaudiobooks.html
+++ b/src/main/resources/templates/teacherViewPages/uploadaudiobooks.html
@@ -9,11 +9,12 @@
     <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 
     <style>
         body {
             font-family: Arial, sans-serif;
-            background-color: #f8f9fa;
+            background-color: var(--clr-bg);
             margin: 0;
             padding: 0;
         }
@@ -22,10 +23,10 @@
             max-width: 900px;
             margin: 50px auto;
             padding: 20px;
-            background-color: white;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--clr-surface);
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-md);
+            box-shadow: var(--shadow-sm);
         }
 
         .header {
@@ -51,14 +52,14 @@
         label {
             font-size: 14px;
             margin-bottom: 5px;
-            color: #333;
+            color: var(--clr-text);
         }
 
         select, input[type="file"] {
             height: 35px;
             padding: 5px 10px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-sm);
             font-size: 14px;
             width: 100%;
         }
@@ -67,14 +68,14 @@
             margin-top: 20px;
             text-decoration: none;
             padding: 10px 20px;
-            color: white;
-            background-color: #007bff;
+            color: var(--clr-text-white);
+            background-color: var(--clr-primary);
             border: none;
-            border-radius: 4px;
+            border-radius: var(--radius-sm);
         }
 
         .btn:hover {
-            background-color: #0056b3;
+            background-color: var(--clr-primary-dark);
         }
     </style>
 </head>

--- a/src/main/resources/templates/teacherViewPages/uploadsampleprograms.html
+++ b/src/main/resources/templates/teacherViewPages/uploadsampleprograms.html
@@ -6,22 +6,23 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
     <style>
         body {
             font-family: Arial, sans-serif;
             margin: 0;
             padding: 0;
-            background-color: #f8f9fa;
+            background-color: var(--clr-bg);
         }
 
         .container {
             max-width: 900px;
             margin: 50px auto;
             padding: 20px;
-            background-color: white;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--clr-surface);
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-md);
+            box-shadow: var(--shadow-sm);
         }
 
         .header {
@@ -57,19 +58,19 @@
         label {
             font-size: 14px;
             margin-bottom: 5px;
-            color: #333;
+            color: var(--clr-text);
         }
 
         select {
             height: 35px;
             padding: 5px 10px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
+            border: 1px solid var(--clr-border);
+            border-radius: var(--radius-sm);
             font-size: 14px;
         }
 
         .resources {
-            display: none; /* Hidden by default */
+            display: none;
             margin-top: 20px;
         }
 
@@ -85,9 +86,9 @@
             margin-left: 10px;
             text-decoration: none;
             padding: 5px 10px;
-            color: white;
-            background-color: #007bff;
-            border-radius: 4px;
+            color: var(--clr-text-white);
+            background-color: var(--clr-primary);
+            border-radius: var(--radius-sm);
         }
 
         .btn i {

--- a/src/main/resources/templates/teacherViewPages/viewUploadedResources.html
+++ b/src/main/resources/templates/teacherViewPages/viewUploadedResources.html
@@ -2,7 +2,7 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>View Uploaded Resources</title>
-    <!-- Add your CSS file if needed -->
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
 
     <style>
         .container {
@@ -17,52 +17,51 @@
         }
 
         table th, table td {
-            border: 1px solid #ddd;
+            border: 1px solid var(--clr-border);
             padding: 8px;
             text-align: center;
         }
 
         table th {
-            background-color: #f4f4f4;
+            background-color: var(--clr-bg);
             font-weight: bold;
         }
 
         .delete-btn {
-            color: white;
-            background-color: red;
+            color: var(--clr-text-white);
+            background-color: var(--clr-danger);
             border: none;
             padding: 5px 10px;
             cursor: pointer;
         }
 
         .delete-btn:hover {
-            background-color: darkred;
+            background-color: var(--clr-danger-dark);
         }
 
         .modal {
-            display: none; /* Hidden by default */
-            position: fixed; /* Stay in place */
-            z-index: 1; /* Sit on top */
+            display: none;
+            position: fixed;
+            z-index: 1;
             left: 0;
             top: 0;
-            width: 100%; /* Full width */
-            height: 100%; /* Full height */
-            overflow: auto; /* Enable scroll if needed */
-            background-color: rgb(0, 0, 0); /* Fallback color */
-            background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
+            width: 100%;
+            height: 100%;
+            overflow: auto;
+            background-color: rgba(0, 0, 0, 0.4);
         }
 
         .modal-content {
-            background-color: #fefefe;
-            margin: 15% auto; /* 15% from the top and centered */
+            background-color: var(--clr-surface);
+            margin: 15% auto;
             padding: 20px;
-            border: 1px solid #888;
-            width: 80%; /* Could be more or less, depending on screen size */
+            border: 1px solid var(--clr-border);
+            width: 80%;
             text-align: center;
         }
 
         .close {
-            color: #aaa;
+            color: var(--clr-text-muted);
             float: right;
             font-size: 28px;
             font-weight: bold;
@@ -71,7 +70,7 @@
         .alert {
             padding: 10px;
             margin: 10px 0;
-            border-radius: 5px;
+            border-radius: var(--radius-sm);
         }
 
         .alert-success {
@@ -82,7 +81,7 @@
 
         .close:hover,
         .close:focus {
-            color: black;
+            color: var(--clr-text);
             text-decoration: none;
             cursor: pointer;
         }


### PR DESCRIPTION
## Summary

- **Security fixes**: expose `AuthenticationManager` bean with `@Lazy` injection to resolve circular dependency warning; add dedicated `NoResourceFoundException` handler so favicon/static-resource 404s no longer pollute the error log
- **Theme system**: introduce `CSS/theme.css` as a single source of truth for all design tokens (colours, radii, shadows, transitions); wire it into every template across all roles; strip duplicate `:root` blocks from role-specific CSS files
- **HOD UI refactor**: rebuild all six HOD pages (`hod`, `add-course`, `manage-course`, `add-subject`, `manage-subject`, `curriculum`) with the same sidebar-based layout used by the admin role; add `hodsidebar.html` offcanvas fragment with active-link highlighting; fix `hodnavbar.html` Bootstrap class conflict (`navbar-light` → `navbar-dark`); clean up `HOD/main.css`

## Commits

| Commit | Description |
|--------|-------------|
| `834faae` | fix(security): expose AuthenticationManager bean and handle static-resource 404s |
| `a7ceb58` | feat(theme): introduce theme.css design tokens and wire into all templates |
| `bae874a` | refactor(hod): rebuild all HOD pages with sidebar layout matching admin design |

## Test plan

- [ ] Login as `admin1` / `password` — admin dashboard and all admin pages load correctly
- [ ] Login as `hod1` / `password` — HOD dashboard shows sidebar, stat-cards, and action-cards
- [ ] Navigate through all HOD pages (Add Course, Manage Courses, Add Subject, Manage Subjects, Curriculum) — sidebar highlights the active link
- [ ] Verify teal colour scheme is consistent across admin, HOD, teacher, and student pages
- [ ] Confirm no ERROR-level logs for favicon.ico requests in the app log