### PR TITLE
feat(hod): announcements, teacher assignment, and admin user-edit fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,20 +11,11 @@ CampusConnect is a Spring Boot web application — a collaborative learning plat
 All commands run from the repository root.
 
 ```bash
-# Run the application (dev mode with hot reload via spring-boot-devtools)
-mvn spring-boot:run
-
-# Build (skip tests)
-mvn package -DskipTests
-
-# Run all tests
-mvn test
-
-# Run a single test class
-mvn test -Dtest=ClassName
-
-# Clean build
-mvn clean package
+mvn spring-boot:run        # dev mode with hot reload
+mvn package -DskipTests    # build
+mvn test                   # run all tests
+mvn test -Dtest=ClassName  # run single test class
+mvn clean package          # clean build
 ```
 
 The app runs at `http://localhost:8080`.
@@ -37,8 +28,6 @@ Requires MySQL Server 8.0+. Run the full schema and seed data as root:
 mysql -u root -p < sql-scripts/databaseScript.sql
 ```
 
-This creates the `campusConnect` database, the `campusConnect` MySQL user (password from `DB_PASSWORD` in your `.env`), all tables, and dummy users. The `departments.sql` script can be run separately for additional department seed data.
-
 **Dummy credentials** (all use password `password`):
 - Admin: `admin1`, `admin2`
 - HOD: `hod1`, `hod2`
@@ -47,10 +36,10 @@ This creates the `campusConnect` database, the `campusConnect` MySQL user (passw
 
 ## Configuration
 
-`src/main/resources/application.properties` — two values typically need updating per environment:
+`src/main/resources/application.properties`:
 
 - `spring.datasource.url/username/password` — DB connection (defaults to `campusConnect`@`localhost`)
-- `file.upload-dir` — absolute path where uploaded files are stored (default is `D:/Uploads/` — **must be changed on Linux/Mac**)
+- `file.upload-dir` — absolute path for uploaded files (default `D:/Uploads/` — **change on Linux/Mac**)
 
 ## Architecture
 
@@ -70,8 +59,6 @@ static/      → CSS, JS, images (under loginResources/ for unauthenticated acce
 
 ### Role-Based Routing
 
-Spring Security enforces URL-prefix authorization. After login, `CustomAuthenticationSuccessHandler` redirects to the role's home:
-
 | Role | URL prefix | Home |
 |------|-----------|------|
 | ROLE_ADMIN | `/admin/**` | `/admin` |
@@ -79,27 +66,25 @@ Spring Security enforces URL-prefix authorization. After login, `CustomAuthentic
 | ROLE_TEACHER | `/teacher/**` | `/teacher` |
 | ROLE_STUDENT | `/student/**` | `/student` |
 
-Authentication uses `JdbcUserDetailsManager` with custom queries against the `members` table (credentials) and `roles` table (authorities).
+Authentication uses `JdbcUserDetailsManager` against the `members` table (credentials) and `roles` table (authorities).
 
 ### Database Schema
 
-Key tables and their relationships:
+Key tables:
 - `members` — users (PK: `user_id`), with `dept_id` FK to `department`
 - `roles` — one role per user (FK to `members`)
 - `department` — departments
 - `department_details` — maps members to departments with a role label
 - `course_details` — courses per department
-- `semester` — semesters (global, not per department)
+- `semester` — semesters scoped per course
 - `subject_details` — subjects per course+semester
-- `file_data` — uploaded file metadata; actual files live on disk at `{upload-dir}/{departmentId}/{fileRole}/{courseId}/{semesterId}/{subjectId}/`
-
-### File Storage
-
-`StorageServiceImplementation` handles file upload/download. Files are stored on the local filesystem (not in the database). The `file_data` table stores metadata including the path. Server-level HTTP compression is enabled in `application.properties` for common MIME types.
+- `file_data` — uploaded file metadata; files on disk at `{upload-dir}/{departmentId}/{fileRole}/{courseId}/{semesterId}/{subjectId}/`
+- `announcements` — department-scoped notices posted by HODs
+- `teacher_subject` — one-to-one assignment of a teacher to a subject
 
 ### Passwords
 
-Passwords are stored with Spring Security's `{noop}` prefix for plain-text (dev/test only). The `{noop}` prefix is prepended explicitly in `AdminContoller.saveUser()` when creating new users.
+Stored with Spring Security's `{noop}` prefix (dev/test only). Prepended explicitly in `AdminController.saveUser()`.
 
 ## Documentation Rules
 
@@ -109,31 +94,21 @@ All new code **must** include Javadoc before the PR is opened. No exceptions.
 
 - Every `public` and `protected` class, interface, and enum
 - Every `public` and `protected` method
-- Every `public` and `protected` field (unless it is self-evident from the name alone)
+- Every `public` and `protected` field (unless self-evident from the name alone)
 
-### Format
+### Rules
 
-```java
-/**
- * One-sentence summary of what this does.
- *
- * @param paramName what this parameter represents
- * @return what is returned, and when it may be null
- * @throws SomeException when and why this is thrown
- */
-```
-
-- First sentence is the summary — keep it to one line
-- `@param` / `@return` / `@throws` only when they add information beyond the method signature
-- Do not restate the method name in prose ("This method saves a user" → bad)
+- First sentence is the summary — one line only
+- `@param` / `@return` / `@throws` only when they add information beyond the signature
+- Do not restate the method name in prose
 
 ### Enforcement
 
 - **Within Claude Code sessions:** a `PostToolUse` hook fires after every `.java` edit and warns about missing Javadoc
-- **At commit time:** `.git/hooks/pre-commit` blocks the commit if staged Java files have undocumented public/protected members
+- **At commit time:** `.git/hooks/pre-commit` blocks commits if staged Java files have undocumented public/protected members
 - Hook script: `.claude/hooks/check-javadoc.py`
 
 ## Project Structure
 
 The Maven project (`pom.xml`, `src/`, `Dockerfile`, `sql-scripts/`) lives at the **repository root**.
-The `archive/` directory holds historical files that are no longer part of the active source tree.
+The `archive/` directory holds historical files no longer in the active source tree.

--- a/sql-scripts/databaseScript.sql
+++ b/sql-scripts/databaseScript.sql
@@ -205,6 +205,45 @@ CREATE TABLE IF NOT EXISTS `file_data`
   COLLATE = utf8mb4_unicode_ci;
 
 
+-- Table structure for table `announcements`
+-- HOD posts department-scoped notices visible to teachers and students.
+DROP TABLE IF EXISTS `announcements`;
+
+CREATE TABLE IF NOT EXISTS `announcements`
+(
+    `id`         INT                                                             NOT NULL AUTO_INCREMENT,
+    `dept_id`    INT                                                             NOT NULL,
+    `author`     VARCHAR(50)  CHARACTER SET latin1                               NOT NULL,
+    `title`      VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  NOT NULL,
+    `body`       TEXT         CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  NOT NULL,
+    `created_at` TIMESTAMP                                                       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    KEY `dept_id` (`dept_id`),
+    CONSTRAINT `fk_dept_announcement`   FOREIGN KEY (`dept_id`) REFERENCES `department` (`department_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `fk_author_announcement` FOREIGN KEY (`author`)  REFERENCES `members`    (`user_id`)       ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = latin1;
+
+
+-- Table structure for table `teacher_subject`
+-- Records which teacher is assigned to teach each subject (at most one teacher per subject).
+DROP TABLE IF EXISTS `teacher_subject`;
+
+CREATE TABLE IF NOT EXISTS `teacher_subject`
+(
+    `id`         INT                        NOT NULL AUTO_INCREMENT,
+    `teacher_id` VARCHAR(50) CHARACTER SET latin1 NOT NULL,
+    `subject_id` INT                        NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uq_subject` (`subject_id`),
+    CONSTRAINT `fk_teacher_ts` FOREIGN KEY (`teacher_id`) REFERENCES `members`         (`user_id`)    ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `fk_subject_ts` FOREIGN KEY (`subject_id`) REFERENCES `subject_details` (`subject_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = latin1;
+
+
 -- Reset the environment variables
 /*!40101 SET SQL_MODE = @OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS = @OLD_FOREIGN_KEY_CHECKS */;

--- a/sql-scripts/databaseScript.sql
+++ b/sql-scripts/databaseScript.sql
@@ -211,19 +211,20 @@ DROP TABLE IF EXISTS `announcements`;
 
 CREATE TABLE IF NOT EXISTS `announcements`
 (
-    `id`         INT                                                             NOT NULL AUTO_INCREMENT,
-    `dept_id`    INT                                                             NOT NULL,
-    `author`     VARCHAR(50)  CHARACTER SET latin1                               NOT NULL,
-    `title`      VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  NOT NULL,
-    `body`       TEXT         CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  NOT NULL,
-    `created_at` TIMESTAMP                                                       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `id`         INT           NOT NULL AUTO_INCREMENT,
+    `dept_id`    INT           NOT NULL,
+    `author`     VARCHAR(50)   NOT NULL,
+    `title`      VARCHAR(200)  NOT NULL,
+    `body`       TEXT          NOT NULL,
+    `created_at` TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`),
     KEY `dept_id` (`dept_id`),
     CONSTRAINT `fk_dept_announcement`   FOREIGN KEY (`dept_id`) REFERENCES `department` (`department_id`) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT `fk_author_announcement` FOREIGN KEY (`author`)  REFERENCES `members`    (`user_id`)       ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE = InnoDB
   AUTO_INCREMENT = 1
-  DEFAULT CHARSET = latin1;
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 
 -- Table structure for table `teacher_subject`
@@ -232,16 +233,17 @@ DROP TABLE IF EXISTS `teacher_subject`;
 
 CREATE TABLE IF NOT EXISTS `teacher_subject`
 (
-    `id`         INT                        NOT NULL AUTO_INCREMENT,
-    `teacher_id` VARCHAR(50) CHARACTER SET latin1 NOT NULL,
-    `subject_id` INT                        NOT NULL,
+    `id`         INT         NOT NULL AUTO_INCREMENT,
+    `teacher_id` VARCHAR(50) NOT NULL,
+    `subject_id` INT         NOT NULL,
     PRIMARY KEY (`id`),
     UNIQUE KEY `uq_subject` (`subject_id`),
     CONSTRAINT `fk_teacher_ts` FOREIGN KEY (`teacher_id`) REFERENCES `members`         (`user_id`)    ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT `fk_subject_ts` FOREIGN KEY (`subject_id`) REFERENCES `subject_details` (`subject_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE = InnoDB
   AUTO_INCREMENT = 1
-  DEFAULT CHARSET = latin1;
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 
 -- Reset the environment variables

--- a/sql-scripts/migrate-add-announcements-teacher-subject.sql
+++ b/sql-scripts/migrate-add-announcements-teacher-subject.sql
@@ -1,0 +1,35 @@
+-- Migration: add announcements and teacher_subject tables
+-- Safe to run on an existing campusConnect database — uses IF NOT EXISTS.
+
+USE `campusConnect`;
+
+-- Announcements: department-scoped notices posted by HODs.
+-- author and title use latin1 to match the existing members/subject_details tables.
+CREATE TABLE IF NOT EXISTS `announcements`
+(
+    `id`         INT                         NOT NULL AUTO_INCREMENT,
+    `dept_id`    INT                         NOT NULL,
+    `author`     VARCHAR(50)  CHARACTER SET latin1 NOT NULL,
+    `title`      VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    `body`       TEXT         CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    `created_at` TIMESTAMP                   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    KEY `dept_id` (`dept_id`),
+    CONSTRAINT `fk_dept_announcement`   FOREIGN KEY (`dept_id`) REFERENCES `department` (`department_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `fk_author_announcement` FOREIGN KEY (`author`)  REFERENCES `members`    (`user_id`)       ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+-- Teacher-subject assignments: one teacher per subject (UNIQUE on subject_id).
+-- teacher_id uses latin1 to match members.user_id.
+CREATE TABLE IF NOT EXISTS `teacher_subject`
+(
+    `id`         INT                        NOT NULL AUTO_INCREMENT,
+    `teacher_id` VARCHAR(50) CHARACTER SET latin1 NOT NULL,
+    `subject_id` INT                        NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uq_subject` (`subject_id`),
+    CONSTRAINT `fk_teacher_ts` FOREIGN KEY (`teacher_id`) REFERENCES `members`         (`user_id`)    ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `fk_subject_ts` FOREIGN KEY (`subject_id`) REFERENCES `subject_details` (`subject_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;

--- a/src/main/java/com/bitsunisage/campusconnect/controller/HodController.java
+++ b/src/main/java/com/bitsunisage/campusconnect/controller/HodController.java
@@ -174,7 +174,8 @@ public class HodController {
             redirectAttributes.addFlashAttribute("errorMessage", "Course name cannot be blank.");
             return "redirect:/hod/manage-course";
         }
-        if (!ownsCourse(courseId)) {
+        User hod = getLoggedInUser();
+        if (!ownsCourse(courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-course";
         }
@@ -195,7 +196,8 @@ public class HodController {
     @PostMapping("/hod/delete-course")
     public String deleteCourse(@RequestParam("courseId") Long courseId,
                                RedirectAttributes redirectAttributes) {
-        if (!ownsCourse(courseId)) {
+        User hod = getLoggedInUser();
+        if (!ownsCourse(courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-course";
         }
@@ -225,7 +227,7 @@ public class HodController {
         User hod = getLoggedInUser();
         model.addAttribute("courses", userService.getCoursesByDepartmentId(hod.getDeptID()));
         if (courseId != null) {
-            if (!ownsCourse(courseId)) {
+            if (!ownsCourse(courseId, hod.getDeptID())) {
                 redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
                 return "redirect:/hod/manage-course";
             }
@@ -247,7 +249,8 @@ public class HodController {
     public String saveSemester(@RequestParam("courseId") Long courseId,
                                @RequestParam("semesterName") String semesterName,
                                RedirectAttributes redirectAttributes) {
-        if (!ownsCourse(courseId)) {
+        User hod = getLoggedInUser();
+        if (!ownsCourse(courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied.");
             return "redirect:/hod/manage-course";
         }
@@ -275,7 +278,8 @@ public class HodController {
     public String deleteSemester(@RequestParam("semesterId") Long semesterId,
                                  @RequestParam("courseId") Long courseId,
                                  RedirectAttributes redirectAttributes) {
-        if (!ownsCourse(courseId)) {
+        User hod = getLoggedInUser();
+        if (!ownsCourse(courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied.");
             return "redirect:/hod/manage-course";
         }
@@ -308,7 +312,8 @@ public class HodController {
             redirectAttributes.addFlashAttribute("errorMessage", "Semester name cannot be blank.");
             return "redirect:/hod/semesters?courseId=" + courseId;
         }
-        if (!ownsCourse(courseId)) {
+        User hod = getLoggedInUser();
+        if (!ownsCourse(courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-course";
         }
@@ -350,7 +355,7 @@ public class HodController {
         if (courseId == null) {
             return "hodViewPages/curriculum";
         }
-        if (!ownsCourse(courseId)) {
+        if (!ownsCourse(courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-course";
         }
@@ -409,7 +414,8 @@ public class HodController {
             redirectAttributes.addFlashAttribute("errorMessage", "Subject name cannot be blank.");
             return "redirect:/hod/curriculum?courseId=" + courseId;
         }
-        if (!ownsCourse((long) courseId)) {
+        User hod = getLoggedInUser();
+        if (!ownsCourse((long) courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-subject";
         }
@@ -469,7 +475,8 @@ public class HodController {
             redirectAttributes.addFlashAttribute("errorMessage", "Subject name cannot be blank.");
             return "redirect:/hod/manage-subject?courseId=" + courseId;
         }
-        if (!ownsCourse((long) courseId)) {
+        User hod = getLoggedInUser();
+        if (!ownsCourse((long) courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-subject";
         }
@@ -500,7 +507,8 @@ public class HodController {
                                 @RequestParam("courseId") int courseId,
                                 @RequestParam(value = "source", defaultValue = "curriculum") String source,
                                 RedirectAttributes redirectAttributes) {
-        if (!ownsCourse((long) courseId)) {
+        User hod = getLoggedInUser();
+        if (!ownsCourse((long) courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-subject";
         }
@@ -534,7 +542,7 @@ public class HodController {
         if (courseId == null) {
             return "hodViewPages/assign-teachers";
         }
-        if (!ownsCourse(courseId)) {
+        if (!ownsCourse(courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-course";
         }
@@ -569,7 +577,8 @@ public class HodController {
                                 @RequestParam(value = "teacherId", required = false) String teacherId,
                                 @RequestParam("courseId") Long courseId,
                                 RedirectAttributes redirectAttributes) {
-        if (!ownsCourse(courseId)) {
+        User hod = getLoggedInUser();
+        if (!ownsCourse(courseId, hod.getDeptID())) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-course";
         }
@@ -578,7 +587,7 @@ public class HodController {
             redirectAttributes.addFlashAttribute("successMessage", "Teacher assignment removed.");
         } else {
             User teacher = userService.findUserByUserId(teacherId);
-            if (teacher == null || !teacher.getDeptID().equals(getLoggedInUser().getDeptID())) {
+            if (teacher == null || !teacher.getDeptID().equals(hod.getDeptID())) {
                 redirectAttributes.addFlashAttribute("errorMessage", "Teacher not found or not in your department.");
                 return "redirect:/hod/assign-teachers?courseId=" + courseId;
             }
@@ -785,15 +794,16 @@ public class HodController {
     }
 
     /**
-     * Returns {@code true} if the given course belongs to the logged-in HOD's department.
-     * Used to guard all write operations so a HOD cannot modify another department's data.
+     * Returns {@code true} if the given course belongs to the supplied department.
+     * Callers are expected to resolve the HOD's department once and pass it in,
+     * avoiding a redundant {@code getLoggedInUser()} DB call inside this helper.
      *
-     * @param courseId course to check
-     * @return {@code true} if ownership is confirmed, {@code false} otherwise
+     * @param courseId  course to check
+     * @param hodDeptId the HOD's department ID, obtained from {@link #getLoggedInUser()}
+     * @return {@code true} if the course's department matches {@code hodDeptId}
      */
-    private boolean ownsCourse(Long courseId) {
+    private boolean ownsCourse(Long courseId, Long hodDeptId) {
         CourseDetails course = userService.getCourseById(courseId);
-        if (course == null) return false;
-        return course.getDepartmentId().equals(getLoggedInUser().getDeptID());
+        return course != null && course.getDepartmentId().equals(hodDeptId);
     }
 }

--- a/src/main/java/com/bitsunisage/campusconnect/controller/HodController.java
+++ b/src/main/java/com/bitsunisage/campusconnect/controller/HodController.java
@@ -1,9 +1,6 @@
 package com.bitsunisage.campusconnect.controller;
 
-import com.bitsunisage.campusconnect.entities.CourseDetails;
-import com.bitsunisage.campusconnect.entities.Semester;
-import com.bitsunisage.campusconnect.entities.SubjectDetails;
-import com.bitsunisage.campusconnect.entities.User;
+import com.bitsunisage.campusconnect.entities.*;
 import com.bitsunisage.campusconnect.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -51,9 +48,12 @@ public class HodController {
         User hod = getLoggedInUser();
         Long deptId = hod.getDeptID();
         model.addAttribute("departmentName", hod.getDepartment());
-        model.addAttribute("totalFaculty", userService.countMembersByDepartmentAndRole(deptId, "TEACHER"));
-        model.addAttribute("totalStudents", userService.countMembersByDepartmentAndRole(deptId, "STUDENT"));
-        model.addAttribute("totalCourses", userService.getCoursesByDepartmentId(deptId).size());
+        model.addAttribute("totalFaculty",   userService.countMembersByDepartmentAndRole(deptId, "TEACHER"));
+        model.addAttribute("totalStudents",  userService.countMembersByDepartmentAndRole(deptId, "STUDENT"));
+        model.addAttribute("totalCourses",   userService.getCoursesByDepartmentId(deptId).size());
+        model.addAttribute("totalSubjects",  userService.countSubjectsByDepartmentId(deptId));
+        model.addAttribute("totalFiles",     userService.getFilesByDepartmentId(deptId).size());
+        model.addAttribute("announcementCount", userService.getAnnouncementsByDeptId(deptId).size());
         return "hodViewPages/hod";
     }
 
@@ -132,6 +132,10 @@ public class HodController {
             return "redirect:/hod/add-course";
         }
         User hod = getLoggedInUser();
+        if (userService.courseNameExistsInDepartment(hod.getDeptID(), courseName)) {
+            redirectAttributes.addFlashAttribute("errorMessage", "A course named \"" + courseName + "\" already exists in your department.");
+            return "redirect:/hod/add-course";
+        }
         CourseDetails course = new CourseDetails();
         course.setCourseName(courseName);
         course.setDepartmentId(hod.getDeptID());
@@ -286,6 +290,45 @@ public class HodController {
         return "redirect:/hod/semesters?courseId=" + courseId;
     }
 
+    /**
+     * Renames a semester after verifying its course belongs to the HOD's department.
+     *
+     * @param semesterId         primary key of the semester to rename
+     * @param semesterName       new name; must not be blank or already used in this course
+     * @param courseId           used for ownership check and redirect
+     * @param redirectAttributes used to pass success/error flash messages
+     * @return redirect to {@code /hod/semesters?courseId=<courseId>}
+     */
+    @PostMapping("/hod/update-semester")
+    public String updateSemester(@RequestParam("semesterId") Long semesterId,
+                                 @RequestParam("semesterName") String semesterName,
+                                 @RequestParam("courseId") Long courseId,
+                                 RedirectAttributes redirectAttributes) {
+        if (semesterName == null || semesterName.isBlank()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Semester name cannot be blank.");
+            return "redirect:/hod/semesters?courseId=" + courseId;
+        }
+        if (!ownsCourse(courseId)) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
+            return "redirect:/hod/manage-course";
+        }
+        Semester existing = userService.getSemesterById(semesterId);
+        if (existing == null) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Semester not found.");
+            return "redirect:/hod/semesters?courseId=" + courseId;
+        }
+        if (!existing.getSemesterName().equals(semesterName)
+                && userService.semesterNameExistsInCourse(courseId, semesterName)) {
+            redirectAttributes.addFlashAttribute("errorMessage",
+                    "A semester named \"" + semesterName + "\" already exists in this course.");
+            return "redirect:/hod/semesters?courseId=" + courseId;
+        }
+        existing.setSemesterName(semesterName);
+        userService.saveSemester(existing);
+        redirectAttributes.addFlashAttribute("successMessage", "Semester renamed successfully.");
+        return "redirect:/hod/semesters?courseId=" + courseId;
+    }
+
     // ── Curriculum ───────────────────────────────────────────────────────────
 
     /**
@@ -295,7 +338,7 @@ public class HodController {
      *
      * @param courseId optional course ID; when absent only the course selector is shown
      * @param model    populated with {@code courses}, and optionally {@code course},
-     *                 {@code semesters}, and {@code subjectsBySemester}
+     *                 {@code semesters}, {@code subjectsBySemester}, and {@code assignedTeachers}
      * @return Thymeleaf template {@code hodViewPages/curriculum}, or redirect on ownership failure
      */
     @GetMapping("/hod/curriculum")
@@ -315,9 +358,13 @@ public class HodController {
         Map<Long, List<SubjectDetails>> grouped = subjects.stream()
                 .collect(Collectors.groupingBy(s -> (long) s.getSemesterId(),
                          LinkedHashMap::new, Collectors.toList()));
+        List<Long> subjectIds = subjects.stream().map(SubjectDetails::getSubjectId).toList();
+        Map<Long, String> assignedTeachers = userService.getAssignmentsBySubjectIds(subjectIds).stream()
+                .collect(Collectors.toMap(TeacherSubject::getSubjectId, TeacherSubject::getTeacherId));
         model.addAttribute("course", userService.getCourseById(courseId));
         model.addAttribute("semesters", userService.getSemestersByCourseId(courseId));
         model.addAttribute("subjectsBySemester", grouped);
+        model.addAttribute("assignedTeachers", assignedTeachers);
         return "hodViewPages/curriculum";
     }
 
@@ -365,6 +412,10 @@ public class HodController {
         if (!ownsCourse((long) courseId)) {
             redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
             return "redirect:/hod/manage-subject";
+        }
+        if (userService.subjectNameExistsInSlot(courseId, semesterId, subjectName)) {
+            redirectAttributes.addFlashAttribute("errorMessage", "A subject named \"" + subjectName + "\" already exists in this semester.");
+            return "redirect:/hod/curriculum?courseId=" + courseId;
         }
         SubjectDetails subject = new SubjectDetails();
         subject.setSubjectName(subjectName);
@@ -461,6 +512,115 @@ public class HodController {
         return "redirect:/hod/curriculum?courseId=" + courseId;
     }
 
+    // ── Teacher-Subject Assignment ───────────────────────────────────────────
+
+    /**
+     * Renders the teacher-assignment page. When {@code courseId} is provided, shows all subjects
+     * for that course grouped by semester, each with their current teacher assignment and
+     * a dropdown to change it. When absent, only the course picker is shown.
+     *
+     * @param courseId optional course filter; when absent only the selector is shown
+     * @param model    populated with courses, teachers, semesters, subjectsBySemester,
+     *                 assignmentsBySubjectId, and optionally course and selectedCourseId
+     * @return Thymeleaf template {@code hodViewPages/assign-teachers}
+     */
+    @GetMapping("/hod/assign-teachers")
+    public String showAssignTeachersPage(@RequestParam(value = "courseId", required = false) Long courseId,
+                                         Model model,
+                                         RedirectAttributes redirectAttributes) {
+        User hod = getLoggedInUser();
+        model.addAttribute("courses", userService.getCoursesByDepartmentId(hod.getDeptID()));
+        model.addAttribute("teachers", userService.getMembersByDepartmentAndRole(hod.getDeptID(), "TEACHER"));
+        if (courseId == null) {
+            return "hodViewPages/assign-teachers";
+        }
+        if (!ownsCourse(courseId)) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
+            return "redirect:/hod/manage-course";
+        }
+        List<SubjectDetails> subjects = userService.getSubjectsByCourseId(courseId.intValue());
+        Map<Long, List<SubjectDetails>> grouped = subjects.stream()
+                .collect(Collectors.groupingBy(s -> (long) s.getSemesterId(),
+                         LinkedHashMap::new, Collectors.toList()));
+        List<Long> subjectIds = subjects.stream().map(SubjectDetails::getSubjectId).toList();
+        Map<Long, TeacherSubject> assignmentsBySubjectId = userService.getAssignmentsBySubjectIds(subjectIds)
+                .stream().collect(Collectors.toMap(TeacherSubject::getSubjectId, a -> a));
+        model.addAttribute("course", userService.getCourseById(courseId));
+        model.addAttribute("semesters", userService.getSemestersByCourseId(courseId));
+        model.addAttribute("subjectsBySemester", grouped);
+        model.addAttribute("assignmentsBySubjectId", assignmentsBySubjectId);
+        model.addAttribute("selectedCourseId", courseId);
+        return "hodViewPages/assign-teachers";
+    }
+
+    /**
+     * Saves or removes a teacher-subject assignment.
+     * When {@code teacherId} is blank or absent, the existing assignment for the subject is removed.
+     * Otherwise the assignment is created or replaced.
+     *
+     * @param subjectId          primary key of the subject being assigned
+     * @param teacherId          login username of the teacher to assign; blank means unassign
+     * @param courseId           used for redirect and ownership check
+     * @param redirectAttributes used to pass success/error flash messages
+     * @return redirect to {@code /hod/assign-teachers?courseId=<courseId>}
+     */
+    @PostMapping("/hod/assign-teacher")
+    public String assignTeacher(@RequestParam("subjectId") Long subjectId,
+                                @RequestParam(value = "teacherId", required = false) String teacherId,
+                                @RequestParam("courseId") Long courseId,
+                                RedirectAttributes redirectAttributes) {
+        if (!ownsCourse(courseId)) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Access denied: course does not belong to your department.");
+            return "redirect:/hod/manage-course";
+        }
+        if (teacherId == null || teacherId.isBlank()) {
+            userService.removeTeacherAssignmentBySubjectId(subjectId);
+            redirectAttributes.addFlashAttribute("successMessage", "Teacher assignment removed.");
+        } else {
+            User teacher = userService.findUserByUserId(teacherId);
+            if (teacher == null || !teacher.getDeptID().equals(getLoggedInUser().getDeptID())) {
+                redirectAttributes.addFlashAttribute("errorMessage", "Teacher not found or not in your department.");
+                return "redirect:/hod/assign-teachers?courseId=" + courseId;
+            }
+            userService.upsertTeacherAssignment(teacherId, subjectId);
+            redirectAttributes.addFlashAttribute("successMessage", "Teacher assigned successfully.");
+        }
+        return "redirect:/hod/assign-teachers?courseId=" + courseId;
+    }
+
+    // ── Department Files ─────────────────────────────────────────────────────
+
+    /**
+     * Renders the department file overview page showing all uploaded files
+     * in the HOD's department, with resolved course, semester, and subject names.
+     *
+     * @param model populated with {@code files}, {@code courseNames}, {@code semesterNames},
+     *              and {@code subjectNames} lookup maps
+     * @return Thymeleaf template {@code hodViewPages/department-files}
+     */
+    @GetMapping("/hod/department-files")
+    public String showDepartmentFilesPage(Model model) {
+        User hod = getLoggedInUser();
+        List<FileData> files = userService.getFilesByDepartmentId(hod.getDeptID());
+
+        List<Long> courseIds   = files.stream().map(FileData::getCourseId).distinct().toList();
+        List<Long> semIds      = files.stream().map(FileData::getSemesterId).distinct().toList();
+        List<Long> subjectIds  = files.stream().map(FileData::getSubjectId).distinct().toList();
+
+        Map<Long, String> courseNames = userService.getCourseName(courseIds).stream()
+                .collect(Collectors.toMap(CourseDetails::getCourseId, CourseDetails::getCourseName));
+        Map<Long, String> semesterNames = userService.getSemesterName(semIds).stream()
+                .collect(Collectors.toMap(Semester::getSemesterId, Semester::getSemesterName));
+        Map<Long, String> subjectNames = userService.getSubjectName(subjectIds).stream()
+                .collect(Collectors.toMap(SubjectDetails::getSubjectId, SubjectDetails::getSubjectName));
+
+        model.addAttribute("files", files);
+        model.addAttribute("courseNames", courseNames);
+        model.addAttribute("semesterNames", semesterNames);
+        model.addAttribute("subjectNames", subjectNames);
+        return "hodViewPages/department-files";
+    }
+
     // ── Department Members ───────────────────────────────────────────────────
 
     /**
@@ -477,6 +637,139 @@ public class HodController {
         model.addAttribute("faculty",  userService.getMembersByDepartmentAndRole(deptId, "TEACHER"));
         model.addAttribute("students", userService.getMembersByDepartmentAndRole(deptId, "STUDENT"));
         return "hodViewPages/members";
+    }
+
+    // ── Announcements ────────────────────────────────────────────────────────
+
+    /**
+     * Renders the announcements management page, listing all announcements for the HOD's
+     * department and providing a form to create a new one.
+     *
+     * @param model populated with {@code announcements} list
+     * @return Thymeleaf template {@code hodViewPages/announcements}
+     */
+    @GetMapping("/hod/announcements")
+    public String showAnnouncementsPage(Model model) {
+        User hod = getLoggedInUser();
+        model.addAttribute("announcements", userService.getAnnouncementsByDeptId(hod.getDeptID()));
+        return "hodViewPages/announcements";
+    }
+
+    /**
+     * Saves a new announcement authored by the logged-in HOD.
+     *
+     * @param title              announcement headline; must not be blank
+     * @param body               announcement body text; must not be blank
+     * @param redirectAttributes used to pass success/error flash messages
+     * @return redirect to {@code /hod/announcements}
+     */
+    @PostMapping("/hod/save-announcement")
+    public String saveAnnouncement(@RequestParam("title") String title,
+                                   @RequestParam("body") String body,
+                                   RedirectAttributes redirectAttributes) {
+        if (title.isBlank() || body.isBlank()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Title and body are required.");
+            return "redirect:/hod/announcements";
+        }
+        User hod = getLoggedInUser();
+        Announcement a = new Announcement();
+        a.setDeptId(hod.getDeptID());
+        a.setAuthor(hod.getUserId());
+        a.setTitle(title.strip());
+        a.setBody(body.strip());
+        userService.saveAnnouncement(a);
+        redirectAttributes.addFlashAttribute("successMessage", "Announcement posted.");
+        return "redirect:/hod/announcements";
+    }
+
+    /**
+     * Deletes an announcement after verifying it belongs to the HOD's department.
+     *
+     * @param id                 primary key of the announcement to delete
+     * @param redirectAttributes used to pass success/error flash messages
+     * @return redirect to {@code /hod/announcements}
+     */
+    @PostMapping("/hod/delete-announcement")
+    public String deleteAnnouncement(@RequestParam("id") Long id,
+                                     RedirectAttributes redirectAttributes) {
+        User hod = getLoggedInUser();
+        userService.getAnnouncementById(id).ifPresent(a -> {
+            if (a.getDeptId().equals(hod.getDeptID())) {
+                userService.deleteAnnouncementById(id);
+            }
+        });
+        redirectAttributes.addFlashAttribute("successMessage", "Announcement deleted.");
+        return "redirect:/hod/announcements";
+    }
+
+    /**
+     * Updates the title and body of an existing announcement.
+     * Only the HOD who owns the department the announcement belongs to may edit it.
+     *
+     * @param id                 primary key of the announcement to update
+     * @param title              new headline; must not be blank
+     * @param body               new body text; must not be blank
+     * @param redirectAttributes flash messages for the next request
+     * @return redirect to {@code /hod/announcements}
+     */
+    @PostMapping("/hod/update-announcement")
+    public String updateAnnouncement(@RequestParam("id") Long id,
+                                     @RequestParam("title") String title,
+                                     @RequestParam("body") String body,
+                                     RedirectAttributes redirectAttributes) {
+        if (title == null || title.isBlank() || body == null || body.isBlank()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Title and message cannot be blank.");
+            return "redirect:/hod/announcements";
+        }
+        User hod = getLoggedInUser();
+        userService.getAnnouncementById(id).ifPresent(a -> {
+            if (a.getDeptId().equals(hod.getDeptID())) {
+                a.setTitle(title.trim());
+                a.setBody(body.trim());
+                userService.saveAnnouncement(a);
+            }
+        });
+        redirectAttributes.addFlashAttribute("successMessage", "Announcement updated.");
+        return "redirect:/hod/announcements";
+    }
+
+    // ── Teacher Workload ─────────────────────────────────────────────────────
+
+    /**
+     * Renders the teacher workload page showing each teacher in the HOD's department
+     * alongside the subjects they are currently assigned to teach.
+     *
+     * @param model populated with {@code teachers}, {@code assignmentsByTeacher} (Map&lt;String,
+     *              List&lt;SubjectDetails&gt;&gt;), and {@code subjectIndex} (Map&lt;Long, SubjectDetails&gt;)
+     * @return Thymeleaf template {@code hodViewPages/workload}
+     */
+    @GetMapping("/hod/workload")
+    public String showWorkloadPage(Model model) {
+        User hod = getLoggedInUser();
+        Long deptId = hod.getDeptID();
+
+        List<User> teachers = userService.getMembersByDepartmentAndRole(deptId, "TEACHER");
+        List<String> teacherIds = teachers.stream().map(User::getUserId).toList();
+        List<TeacherSubject> assignments = userService.getAssignmentsByTeacherIds(teacherIds);
+
+        List<Long> subjectIds = assignments.stream().map(TeacherSubject::getSubjectId).distinct().toList();
+        Map<Long, SubjectDetails> subjectIndex = userService.getSubjectName(subjectIds).stream()
+                .collect(Collectors.toMap(SubjectDetails::getSubjectId, s -> s));
+
+        Map<String, List<SubjectDetails>> byTeacher = new LinkedHashMap<>();
+        for (User t : teachers) {
+            byTeacher.put(t.getUserId(), new java.util.ArrayList<>());
+        }
+        for (TeacherSubject ts : assignments) {
+            SubjectDetails sd = subjectIndex.get(ts.getSubjectId());
+            if (sd != null) {
+                byTeacher.computeIfAbsent(ts.getTeacherId(), k -> new java.util.ArrayList<>()).add(sd);
+            }
+        }
+
+        model.addAttribute("teachers", teachers);
+        model.addAttribute("assignmentsByTeacher", byTeacher);
+        return "hodViewPages/workload";
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/src/main/java/com/bitsunisage/campusconnect/controller/HodController.java
+++ b/src/main/java/com/bitsunisage/campusconnect/controller/HodController.java
@@ -665,6 +665,29 @@ public class HodController {
     }
 
     /**
+     * Renders the edit form for a single announcement.
+     * Redirects with an error if the announcement does not exist or belongs to a different department.
+     *
+     * @param id                 primary key of the announcement to edit
+     * @param model              populated with {@code announcement}
+     * @param redirectAttributes used to pass an error flash if the announcement is not found
+     * @return Thymeleaf template {@code hodViewPages/edit-announcement}, or redirect on failure
+     */
+    @GetMapping("/hod/edit-announcement")
+    public String showEditAnnouncementPage(@RequestParam("id") Long id,
+                                           Model model,
+                                           RedirectAttributes redirectAttributes) {
+        User hod = getLoggedInUser();
+        return userService.getAnnouncementById(id)
+                .filter(a -> a.getDeptId().equals(hod.getDeptID()))
+                .map(a -> { model.addAttribute("announcement", a); return "hodViewPages/edit-announcement"; })
+                .orElseGet(() -> {
+                    redirectAttributes.addFlashAttribute("errorMessage", "Announcement not found.");
+                    return "redirect:/hod/announcements";
+                });
+    }
+
+    /**
      * Saves a new announcement authored by the logged-in HOD.
      *
      * @param title              announcement headline; must not be blank

--- a/src/main/java/com/bitsunisage/campusconnect/controller/StudentController.java
+++ b/src/main/java/com/bitsunisage/campusconnect/controller/StudentController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -59,12 +60,19 @@ public class StudentController {
     }
 
     /**
-     * Renders the student dashboard home page.
+     * Renders the student dashboard home page, including any announcements posted by the
+     * HOD of the student's department.
      *
+     * @param model populated with {@code announcements} for the student's department
      * @return Thymeleaf template {@code studentViewPages/indexstudent}
      */
     @GetMapping("/student")
-    public String getStudent() {
+    public String getStudent(Model model) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        User student = userService.findUserByUserId(username);
+        if (student != null && student.getDeptID() != null) {
+            model.addAttribute("announcements", userService.getAnnouncementsByDeptId(student.getDeptID()));
+        }
         return "studentViewPages/indexstudent";
     }
 

--- a/src/main/java/com/bitsunisage/campusconnect/controller/TeacherController.java
+++ b/src/main/java/com/bitsunisage/campusconnect/controller/TeacherController.java
@@ -5,6 +5,7 @@ import com.bitsunisage.campusconnect.entities.*;
 import com.bitsunisage.campusconnect.service.StorageService;
 import com.bitsunisage.campusconnect.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,12 +58,19 @@ public class TeacherController {
     }
 
     /**
-     * Renders the teacher dashboard home page.
+     * Renders the teacher dashboard home page, including any announcements posted by the
+     * HOD of the teacher's department.
      *
+     * @param model populated with {@code announcements} for the teacher's department
      * @return Thymeleaf template {@code teacherViewPages/indexteacher}
      */
     @GetMapping("/teacher")
-    public String homePage() {
+    public String homePage(Model model) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        User teacher = userService.findUserByUserId(username);
+        if (teacher != null && teacher.getDeptID() != null) {
+            model.addAttribute("announcements", userService.getAnnouncementsByDeptId(teacher.getDeptID()));
+        }
         return "teacherViewPages/indexteacher";
     }
 

--- a/src/main/java/com/bitsunisage/campusconnect/entities/Announcement.java
+++ b/src/main/java/com/bitsunisage/campusconnect/entities/Announcement.java
@@ -1,0 +1,100 @@
+package com.bitsunisage.campusconnect.entities;
+
+import jakarta.persistence.*;
+
+import java.sql.Timestamp;
+
+/**
+ * JPA entity for the {@code announcements} table.
+ * Represents a department-scoped notice posted by an HOD.
+ * Teachers and students in the same department can read these announcements.
+ */
+@Entity
+@Table(name = "announcements")
+public class Announcement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    /** Numeric ID of the department this announcement belongs to (FK to {@code department.department_id}). */
+    @Column(name = "dept_id", nullable = false)
+    private Long deptId;
+
+    /** Login username of the HOD who posted this announcement (FK to {@code members.user_id}). */
+    @Column(name = "author", nullable = false)
+    private String author;
+
+    /** Short headline for the announcement; displayed in summary lists. */
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    /** Full announcement body text. */
+    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    /** Timestamp when the row was inserted; set by the database default. */
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Timestamp createdAt;
+
+    /** @return surrogate primary key */
+    public Long getId() {
+        return id;
+    }
+
+    /** @param id surrogate primary key */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /** @return department ID this announcement is scoped to */
+    public Long getDeptId() {
+        return deptId;
+    }
+
+    /** @param deptId department ID */
+    public void setDeptId(Long deptId) {
+        this.deptId = deptId;
+    }
+
+    /** @return login username of the posting HOD */
+    public String getAuthor() {
+        return author;
+    }
+
+    /** @param author login username */
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    /** @return announcement headline */
+    public String getTitle() {
+        return title;
+    }
+
+    /** @param title announcement headline */
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    /** @return full announcement body */
+    public String getBody() {
+        return body;
+    }
+
+    /** @param body announcement body */
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    /** @return creation timestamp (database-managed) */
+    public Timestamp getCreatedAt() {
+        return createdAt;
+    }
+
+    /** @param createdAt creation timestamp */
+    public void setCreatedAt(Timestamp createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/bitsunisage/campusconnect/entities/TeacherSubject.java
+++ b/src/main/java/com/bitsunisage/campusconnect/entities/TeacherSubject.java
@@ -1,0 +1,56 @@
+package com.bitsunisage.campusconnect.entities;
+
+import jakarta.persistence.*;
+
+/**
+ * JPA entity for the {@code teacher_subject} table.
+ * Records which teacher is assigned to teach a given subject.
+ * At most one teacher may be assigned per subject (enforced by the unique key on {@code subject_id}).
+ */
+@Entity
+@Table(name = "teacher_subject")
+public class TeacherSubject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    /** Login username of the assigned teacher (FK to {@code members.user_id}). */
+    @Column(name = "teacher_id", nullable = false)
+    private String teacherId;
+
+    /** Primary key of the subject being taught (FK to {@code subject_details.subject_id}). */
+    @Column(name = "subject_id", nullable = false, unique = true)
+    private Long subjectId;
+
+    /** @return surrogate primary key of this assignment record */
+    public Long getId() {
+        return id;
+    }
+
+    /** @param id surrogate primary key */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /** @return login username of the assigned teacher */
+    public String getTeacherId() {
+        return teacherId;
+    }
+
+    /** @param teacherId login username of the teacher */
+    public void setTeacherId(String teacherId) {
+        this.teacherId = teacherId;
+    }
+
+    /** @return subject primary key this assignment applies to */
+    public Long getSubjectId() {
+        return subjectId;
+    }
+
+    /** @param subjectId subject primary key */
+    public void setSubjectId(Long subjectId) {
+        this.subjectId = subjectId;
+    }
+}

--- a/src/main/java/com/bitsunisage/campusconnect/repository/AnnouncementDAO.java
+++ b/src/main/java/com/bitsunisage/campusconnect/repository/AnnouncementDAO.java
@@ -1,0 +1,23 @@
+package com.bitsunisage.campusconnect.repository;
+
+import com.bitsunisage.campusconnect.entities.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Repository for {@link Announcement} (the {@code announcements} table).
+ * Announcements are scoped to a single department and authored by an HOD.
+ */
+@Repository
+public interface AnnouncementDAO extends JpaRepository<Announcement, Long> {
+
+    /**
+     * Returns all announcements for the given department, newest first.
+     *
+     * @param deptId the department primary key
+     * @return list of announcements; empty if none posted
+     */
+    List<Announcement> findByDeptIdOrderByCreatedAtDesc(Long deptId);
+}

--- a/src/main/java/com/bitsunisage/campusconnect/repository/CourseDetailsDAO.java
+++ b/src/main/java/com/bitsunisage/campusconnect/repository/CourseDetailsDAO.java
@@ -43,4 +43,14 @@ public interface CourseDetailsDAO extends JpaRepository<CourseDetails, Integer> 
      * @param courseId the course ID to delete
      */
     void deleteByCourseId(Long courseId);
+
+    /**
+     * Returns {@code true} if a course with the given name already exists in the given department.
+     * Used to prevent duplicate course names within a department.
+     *
+     * @param departmentId department to scope the check to
+     * @param courseName   name to test (case-sensitive)
+     * @return {@code true} if a matching course exists
+     */
+    boolean existsByDepartmentIdAndCourseName(Long departmentId, String courseName);
 }

--- a/src/main/java/com/bitsunisage/campusconnect/repository/FileDAO.java
+++ b/src/main/java/com/bitsunisage/campusconnect/repository/FileDAO.java
@@ -57,6 +57,14 @@ public interface FileDAO extends JpaRepository<FileData, Long> {
                                       @Param("fileRole") String fileRole);
 
     /**
+     * Returns all files uploaded within the given department, ordered by upload date descending.
+     *
+     * @param departmentId the department's numeric ID
+     * @return list of matching {@link FileData} records; empty if none
+     */
+    List<FileData> findByFileDepartmentIdOrderByUploadDateDesc(Long departmentId);
+
+    /**
      * Looks up a file by its primary key.
      *
      * @param id file primary key

--- a/src/main/java/com/bitsunisage/campusconnect/repository/SemesterDAO.java
+++ b/src/main/java/com/bitsunisage/campusconnect/repository/SemesterDAO.java
@@ -36,4 +36,14 @@ public interface SemesterDAO extends JpaRepository<Semester, Integer> {
      * @param semesterId the semester ID to delete
      */
     void deleteBySemesterId(Long semesterId);
+
+    /**
+     * Returns {@code true} if a semester with this name already exists in the given course.
+     * Used to prevent duplicate semester names within the same course.
+     *
+     * @param courseId     course primary key
+     * @param semesterName name to test (case-sensitive)
+     * @return {@code true} if a matching semester exists
+     */
+    boolean existsByCourseIdAndSemesterName(Long courseId, String semesterName);
 }

--- a/src/main/java/com/bitsunisage/campusconnect/repository/SubjectDetailsDAO.java
+++ b/src/main/java/com/bitsunisage/campusconnect/repository/SubjectDetailsDAO.java
@@ -51,4 +51,23 @@ public interface SubjectDetailsDAO extends JpaRepository<SubjectDetails, String>
      * @return count of subjects in that semester
      */
     int countBySemesterId(int semesterId);
+
+    /**
+     * Returns {@code true} if a subject with the given name already exists in the given course and semester.
+     * Used to prevent duplicate subject names within the same course-semester slot.
+     *
+     * @param courseId    course primary key
+     * @param semesterId  semester primary key
+     * @param subjectName name to test (case-sensitive)
+     * @return {@code true} if a matching subject exists
+     */
+    boolean existsByCourseIdAndSemesterIdAndSubjectName(int courseId, int semesterId, String subjectName);
+
+    /**
+     * Counts all subjects belonging to the given course.
+     *
+     * @param courseId course primary key
+     * @return number of subjects in that course
+     */
+    int countByCourseId(int courseId);
 }

--- a/src/main/java/com/bitsunisage/campusconnect/repository/TeacherSubjectDAO.java
+++ b/src/main/java/com/bitsunisage/campusconnect/repository/TeacherSubjectDAO.java
@@ -1,0 +1,49 @@
+package com.bitsunisage.campusconnect.repository;
+
+import com.bitsunisage.campusconnect.entities.TeacherSubject;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository for {@link TeacherSubject} (the {@code teacher_subject} table).
+ * Each row records that one teacher is assigned to teach one subject.
+ */
+@Repository
+public interface TeacherSubjectDAO extends JpaRepository<TeacherSubject, Long> {
+
+    /**
+     * Finds all assignments whose subject ID is in the given list.
+     *
+     * @param subjectIds list of subject primary keys to query
+     * @return list of matching assignments; empty if none
+     */
+    List<TeacherSubject> findBySubjectIdIn(List<Long> subjectIds);
+
+    /**
+     * Finds the assignment for a specific subject, if one exists.
+     *
+     * @param subjectId subject primary key
+     * @return an {@link Optional} containing the assignment, or empty if unassigned
+     */
+    Optional<TeacherSubject> findBySubjectId(Long subjectId);
+
+    /**
+     * Deletes the assignment for the given subject.
+     * No-op if no assignment exists for that subject.
+     *
+     * @param subjectId subject primary key
+     */
+    void deleteBySubjectId(Long subjectId);
+
+    /**
+     * Returns all assignments where the teacher is one of the given user IDs.
+     * Used to build a per-teacher workload summary.
+     *
+     * @param teacherIds list of teacher login usernames
+     * @return list of matching assignments; empty if none
+     */
+    List<TeacherSubject> findByTeacherIdIn(List<String> teacherIds);
+}

--- a/src/main/java/com/bitsunisage/campusconnect/service/UserService.java
+++ b/src/main/java/com/bitsunisage/campusconnect/service/UserService.java
@@ -3,6 +3,7 @@ package com.bitsunisage.campusconnect.service;
 import com.bitsunisage.campusconnect.entities.*;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Service interface for all user and academic-catalogue operations.
@@ -329,4 +330,119 @@ public interface UserService {
      * @return list of matching users; empty if none
      */
     List<User> getMembersByDepartmentAndRole(Long deptId, String role);
+
+    /**
+     * Returns all uploaded files belonging to the given department, newest first.
+     *
+     * @param deptId department primary key
+     * @return list of {@link FileData} records; empty if none
+     */
+    List<FileData> getFilesByDepartmentId(Long deptId);
+
+    // ── Teacher-Subject Assignment ────────────────────────────────────────────
+
+    /**
+     * Returns all teacher-subject assignments for the given list of subject IDs.
+     *
+     * @param subjectIds list of subject primary keys to query
+     * @return list of matching {@link TeacherSubject} records; empty if none
+     */
+    List<TeacherSubject> getAssignmentsBySubjectIds(List<Long> subjectIds);
+
+    /**
+     * Creates or replaces the teacher assignment for a subject.
+     * If the subject already has an assigned teacher, that assignment is overwritten.
+     *
+     * @param teacherId login username of the teacher to assign
+     * @param subjectId primary key of the subject
+     */
+    void upsertTeacherAssignment(String teacherId, Long subjectId);
+
+    /**
+     * Removes the teacher assignment for the given subject, if one exists.
+     * No-op if the subject has no assignment.
+     *
+     * @param subjectId primary key of the subject
+     */
+    void removeTeacherAssignmentBySubjectId(Long subjectId);
+
+    /**
+     * Returns all assignments where the teacher belongs to the given list of usernames.
+     * Used to build the per-teacher workload summary for an HOD.
+     *
+     * @param teacherIds list of teacher login usernames
+     * @return list of matching {@link TeacherSubject} records; empty if none
+     */
+    List<TeacherSubject> getAssignmentsByTeacherIds(List<String> teacherIds);
+
+    // ── Announcements ─────────────────────────────────────────────────────────
+
+    /**
+     * Returns all announcements for the given department, newest first.
+     *
+     * @param deptId department primary key
+     * @return list of {@link Announcement} records; empty if none posted
+     */
+    List<Announcement> getAnnouncementsByDeptId(Long deptId);
+
+    /**
+     * Looks up an announcement by its primary key.
+     *
+     * @param id announcement primary key
+     * @return an {@link Optional} containing the record, or empty if not found
+     */
+    Optional<Announcement> getAnnouncementById(Long id);
+
+    /**
+     * Persists a new or updated announcement record.
+     *
+     * @param announcement the {@link Announcement} to save
+     * @return the saved entity (ID populated for new records)
+     */
+    Announcement saveAnnouncement(Announcement announcement);
+
+    /**
+     * Deletes an announcement by its primary key.
+     *
+     * @param id announcement primary key
+     */
+    void deleteAnnouncementById(Long id);
+
+    // ── Duplicate-name Checks ─────────────────────────────────────────────────
+
+    /**
+     * Returns {@code true} if a course with this name already exists in the given department.
+     *
+     * @param deptId     department primary key
+     * @param courseName course name to test
+     * @return {@code true} if a duplicate exists
+     */
+    boolean courseNameExistsInDepartment(Long deptId, String courseName);
+
+    /**
+     * Returns {@code true} if a semester with this name already exists in the given course.
+     *
+     * @param courseId     course primary key
+     * @param semesterName semester name to test
+     * @return {@code true} if a duplicate exists
+     */
+    boolean semesterNameExistsInCourse(Long courseId, String semesterName);
+
+    /**
+     * Returns {@code true} if a subject with this name already exists in the given course and semester.
+     *
+     * @param courseId    course primary key
+     * @param semesterId  semester primary key
+     * @param subjectName subject name to test
+     * @return {@code true} if a duplicate exists
+     */
+    boolean subjectNameExistsInSlot(int courseId, int semesterId, String subjectName);
+
+    /**
+     * Counts all subjects across all courses belonging to the given department.
+     *
+     * @param deptId department primary key
+     * @return total subject count for the department
+     */
+    int countSubjectsByDepartmentId(Long deptId);
 }

--- a/src/main/java/com/bitsunisage/campusconnect/service/UserServiceImplementation.java
+++ b/src/main/java/com/bitsunisage/campusconnect/service/UserServiceImplementation.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * {@link UserService} implementation backed by Spring Data JPA repositories.
@@ -23,6 +24,9 @@ public class UserServiceImplementation implements UserService {
     private final CourseDetailsDAO courseDetailsDAO;
     private final SemesterDAO semesterDAO;
     private final SubjectDetailsDAO subjectDetailsDAO;
+    private final FileDAO fileDAO;
+    private final TeacherSubjectDAO teacherSubjectDAO;
+    private final AnnouncementDAO announcementDAO;
 
     /**
      * Constructs the service with all required repositories injected by Spring.
@@ -34,6 +38,9 @@ public class UserServiceImplementation implements UserService {
      * @param courseDetailsDAO      repository for {@link CourseDetails}
      * @param semesterDAO           repository for {@link Semester}
      * @param subjectDetailsDAO     repository for {@link SubjectDetails}
+     * @param fileDAO               repository for {@link FileData}
+     * @param teacherSubjectDAO     repository for {@link TeacherSubject}
+     * @param announcementDAO       repository for {@link Announcement}
      */
     @Autowired
     public UserServiceImplementation(UserDAO userDAO, RoleDAO roleDAO,
@@ -41,7 +48,10 @@ public class UserServiceImplementation implements UserService {
                                      DepartmentDetailsDAO departmentDetailsDAO,
                                      CourseDetailsDAO courseDetailsDAO,
                                      SemesterDAO semesterDAO,
-                                     SubjectDetailsDAO subjectDetailsDAO) {
+                                     SubjectDetailsDAO subjectDetailsDAO,
+                                     FileDAO fileDAO,
+                                     TeacherSubjectDAO teacherSubjectDAO,
+                                     AnnouncementDAO announcementDAO) {
         this.userDAO = userDAO;
         this.roleDAO = roleDAO;
         this.departmentDAO = departmentDAO;
@@ -49,6 +59,9 @@ public class UserServiceImplementation implements UserService {
         this.courseDetailsDAO = courseDetailsDAO;
         this.semesterDAO = semesterDAO;
         this.subjectDetailsDAO = subjectDetailsDAO;
+        this.fileDAO = fileDAO;
+        this.teacherSubjectDAO = teacherSubjectDAO;
+        this.announcementDAO = announcementDAO;
     }
 
     /** {@inheritDoc} */
@@ -299,5 +312,91 @@ public class UserServiceImplementation implements UserService {
                 .map(DepartmentDetails::getUserName)
                 .toList();
         return userDAO.findByUserIdIn(userIds);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<FileData> getFilesByDepartmentId(Long deptId) {
+        return fileDAO.findByFileDepartmentIdOrderByUploadDateDesc(deptId);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<TeacherSubject> getAssignmentsBySubjectIds(List<Long> subjectIds) {
+        if (subjectIds == null || subjectIds.isEmpty()) return List.of();
+        return teacherSubjectDAO.findBySubjectIdIn(subjectIds);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void upsertTeacherAssignment(String teacherId, Long subjectId) {
+        TeacherSubject assignment = teacherSubjectDAO.findBySubjectId(subjectId).orElse(new TeacherSubject());
+        assignment.setTeacherId(teacherId);
+        assignment.setSubjectId(subjectId);
+        teacherSubjectDAO.save(assignment);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void removeTeacherAssignmentBySubjectId(Long subjectId) {
+        teacherSubjectDAO.findBySubjectId(subjectId).ifPresent(teacherSubjectDAO::delete);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<TeacherSubject> getAssignmentsByTeacherIds(List<String> teacherIds) {
+        if (teacherIds == null || teacherIds.isEmpty()) return List.of();
+        return teacherSubjectDAO.findByTeacherIdIn(teacherIds);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<Announcement> getAnnouncementsByDeptId(Long deptId) {
+        return announcementDAO.findByDeptIdOrderByCreatedAtDesc(deptId);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Optional<Announcement> getAnnouncementById(Long id) {
+        return announcementDAO.findById(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Announcement saveAnnouncement(Announcement announcement) {
+        return announcementDAO.save(announcement);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void deleteAnnouncementById(Long id) {
+        announcementDAO.deleteById(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean courseNameExistsInDepartment(Long deptId, String courseName) {
+        return courseDetailsDAO.existsByDepartmentIdAndCourseName(deptId, courseName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean semesterNameExistsInCourse(Long courseId, String semesterName) {
+        return semesterDAO.existsByCourseIdAndSemesterName(courseId, semesterName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean subjectNameExistsInSlot(int courseId, int semesterId, String subjectName) {
+        return subjectDetailsDAO.existsByCourseIdAndSemesterIdAndSubjectName(courseId, semesterId, subjectName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int countSubjectsByDepartmentId(Long deptId) {
+        List<CourseDetails> courses = courseDetailsDAO.findByDepartmentId(deptId);
+        return courses.stream()
+                .mapToInt(c -> subjectDetailsDAO.countByCourseId(c.getCourseId().intValue()))
+                .sum();
     }
 }

--- a/src/main/resources/templates/adminViewPages/add-user.html
+++ b/src/main/resources/templates/adminViewPages/add-user.html
@@ -26,6 +26,7 @@
                 </div>
 
                 <form th:action="@{/admin/save}" method="POST" th:object="${user}">
+                    <input type="hidden" th:field="*{id}">
 
                     <div class="mb-3">
                         <label class="form-label fw-semibold" for="username">Username</label>

--- a/src/main/resources/templates/hodViewPages/announcements.html
+++ b/src/main/resources/templates/hodViewPages/announcements.html
@@ -65,34 +65,14 @@
                            th:text="${#dates.format(ann.createdAt, 'dd MMM yyyy, HH:mm')} + ' · ' + ${ann.author}"></small>
                 </div>
                 <div class="d-flex gap-2 flex-shrink-0">
-                    <button class="btn btn-sm btn-outline-secondary"
-                            type="button"
-                            th:data-bs-target="'#edit-ann-' + ${ann.id}"
-                            data-bs-toggle="collapse"
-                            aria-expanded="false">Edit</button>
+                    <a th:href="@{/hod/edit-announcement(id=${ann.id})}"
+                       class="btn btn-sm btn-outline-secondary">Edit</a>
                     <form th:action="@{/hod/delete-announcement}" method="post"
                           onsubmit="return confirm('Delete this announcement?')">
                         <input type="hidden" name="id" th:value="${ann.id}">
                         <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
                     </form>
                 </div>
-            </div>
-            <!-- Inline edit form (collapsed by default) -->
-            <div th:id="'edit-ann-' + ${ann.id}" class="collapse mt-3 pt-3 border-top">
-                <form th:action="@{/hod/update-announcement}" method="post">
-                    <input type="hidden" name="id" th:value="${ann.id}">
-                    <div class="mb-2">
-                        <label class="form-label fw-semibold small">Title</label>
-                        <input type="text" name="title" th:value="${ann.title}"
-                               class="form-control form-control-sm" maxlength="200" required>
-                    </div>
-                    <div class="mb-2">
-                        <label class="form-label fw-semibold small">Message</label>
-                        <textarea name="body" class="form-control form-control-sm" rows="3"
-                                  required th:text="${ann.body}"></textarea>
-                    </div>
-                    <button type="submit" class="btn btn-sm btn-success">Save Changes</button>
-                </form>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/hodViewPages/announcements.html
+++ b/src/main/resources/templates/hodViewPages/announcements.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
+    <title>Announcements &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/HOD/portal.css}">
+</head>
+<body>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
+
+<div class="hod-page-content">
+<main>
+<div class="hod-container">
+
+    <div class="hod-page-header">
+        <h2 class="hod-page-header__title">Announcements</h2>
+    </div>
+
+    <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
+        <span th:text="${successMessage}"></span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <div th:if="${errorMessage}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${errorMessage}"></span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <!-- Post new announcement -->
+    <p class="hod-section-label">Post New Announcement</p>
+    <div class="hod-form-card mb-5">
+        <form th:action="@{/hod/save-announcement}" method="post">
+            <div class="mb-3">
+                <label class="form-label fw-semibold" for="title">Title</label>
+                <input id="title" type="text" name="title" class="form-control"
+                       placeholder="e.g. Exam schedule update" maxlength="200" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label fw-semibold" for="body">Message</label>
+                <textarea id="body" name="body" class="form-control" rows="4"
+                          placeholder="Write your announcement here…" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Post Announcement</button>
+        </form>
+    </div>
+
+    <!-- Existing announcements -->
+    <p class="hod-section-label">Posted Announcements</p>
+
+    <div th:if="${announcements.empty}" class="text-muted small mb-4">
+        No announcements posted yet.
+    </div>
+
+    <div th:unless="${announcements.empty}">
+        <div th:each="ann : ${announcements}" class="hod-table-card mb-3 p-3">
+            <!-- Read view -->
+            <div class="d-flex justify-content-between align-items-start gap-2 flex-wrap">
+                <div class="flex-grow-1">
+                    <h6 class="fw-bold mb-1" th:text="${ann.title}"></h6>
+                    <p class="mb-1 text-muted" style="white-space:pre-wrap;" th:text="${ann.body}"></p>
+                    <small class="text-muted"
+                           th:text="${#dates.format(ann.createdAt, 'dd MMM yyyy, HH:mm')} + ' · ' + ${ann.author}"></small>
+                </div>
+                <div class="d-flex gap-2 flex-shrink-0">
+                    <button class="btn btn-sm btn-outline-secondary"
+                            type="button"
+                            th:data-bs-target="'#edit-ann-' + ${ann.id}"
+                            data-bs-toggle="collapse"
+                            aria-expanded="false">Edit</button>
+                    <form th:action="@{/hod/delete-announcement}" method="post"
+                          onsubmit="return confirm('Delete this announcement?')">
+                        <input type="hidden" name="id" th:value="${ann.id}">
+                        <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                    </form>
+                </div>
+            </div>
+            <!-- Inline edit form (collapsed by default) -->
+            <div th:id="'edit-ann-' + ${ann.id}" class="collapse mt-3 pt-3 border-top">
+                <form th:action="@{/hod/update-announcement}" method="post">
+                    <input type="hidden" name="id" th:value="${ann.id}">
+                    <div class="mb-2">
+                        <label class="form-label fw-semibold small">Title</label>
+                        <input type="text" name="title" th:value="${ann.title}"
+                               class="form-control form-control-sm" maxlength="200" required>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label fw-semibold small">Message</label>
+                        <textarea name="body" class="form-control form-control-sm" rows="3"
+                                  required th:text="${ann.body}"></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-sm btn-success">Save Changes</button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+</div>
+</main>
+<div th:replace="~{hodViewPages/hodfooter :: hodfooter}"></div>
+</div>
+
+<script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/hodViewPages/assign-teachers.html
+++ b/src/main/resources/templates/hodViewPages/assign-teachers.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
+    <title>Assign Teachers &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/HOD/portal.css}">
+</head>
+<body>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
+
+<div class="hod-page-content">
+<main>
+<div class="hod-container">
+
+    <div class="hod-page-header">
+        <h2 class="hod-page-header__title">Assign Teachers to Subjects</h2>
+    </div>
+
+    <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
+        <span th:text="${successMessage}"></span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <div th:if="${errorMessage}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${errorMessage}"></span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div th:if="${courses.empty}" class="alert alert-warning">
+        No courses found. <a th:href="@{/hod/add-course}">Add a course first.</a>
+    </div>
+
+    <!-- Course filter -->
+    <form th:unless="${courses.empty}" th:action="@{/hod/assign-teachers}" method="get"
+          class="d-flex gap-2 align-items-center mb-4 flex-wrap">
+        <select name="courseId" class="form-select" style="max-width:320px;" required>
+            <option value="" disabled th:selected="${selectedCourseId == null}">Select a course</option>
+            <option th:each="course : ${courses}"
+                    th:value="${course.courseId}"
+                    th:text="${course.courseName}"
+                    th:selected="${course.courseId == selectedCourseId}"></option>
+        </select>
+        <button type="submit" class="btn btn-primary">View Subjects</button>
+    </form>
+
+    <div th:if="${teachers != null and teachers.empty and selectedCourseId != null}"
+         class="alert alert-info">
+        No teachers are assigned to this department. Add teachers via the Admin portal first.
+    </div>
+
+    <!-- Subjects grouped by semester -->
+    <div th:if="${subjectsBySemester != null}">
+        <div th:if="${subjectsBySemester.empty}" class="alert alert-info">
+            No subjects found for this course. <a th:href="@{/hod/add-subject}">Add a subject first.</a>
+        </div>
+
+        <div th:unless="${subjectsBySemester.empty}" th:each="sem : ${semesters}">
+            <th:block th:with="semSubjects=${subjectsBySemester[sem.semesterId]}">
+                <div th:unless="${semSubjects == null or semSubjects.empty}" class="mb-4">
+                    <p class="hod-section-label" th:text="${sem.semesterName}">Semester</p>
+                    <div class="hod-table-card">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0 align-middle">
+                                <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Subject</th>
+                                    <th>Assigned Teacher</th>
+                                    <th style="min-width:280px;">Change Assignment</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr th:each="subject, stat : ${semSubjects}">
+                                    <td th:text="${stat.count}" class="text-muted"></td>
+                                    <td th:text="${subject.subjectName}"></td>
+                                    <td>
+                                        <span th:if="${assignmentsBySubjectId[subject.subjectId] != null}"
+                                              th:text="${assignmentsBySubjectId[subject.subjectId].teacherId}"
+                                              class="badge bg-success"></span>
+                                        <span th:unless="${assignmentsBySubjectId[subject.subjectId] != null}"
+                                              class="text-muted small">Unassigned</span>
+                                    </td>
+                                    <td>
+                                        <form th:action="@{/hod/assign-teacher}" method="post"
+                                              class="d-flex gap-1 align-items-center">
+                                            <input type="hidden" name="subjectId" th:value="${subject.subjectId}">
+                                            <input type="hidden" name="courseId"  th:value="${selectedCourseId}">
+                                            <select name="teacherId" class="form-select form-select-sm" style="max-width:200px;">
+                                                <option value="">— Unassigned —</option>
+                                                <option th:each="teacher : ${teachers}"
+                                                        th:value="${teacher.userId}"
+                                                        th:text="${teacher.userId}"
+                                                        th:selected="${assignmentsBySubjectId[subject.subjectId] != null
+                                                                       and assignmentsBySubjectId[subject.subjectId].teacherId == teacher.userId}">
+                                                </option>
+                                            </select>
+                                            <button type="submit" class="btn btn-sm btn-primary text-nowrap">Save</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </th:block>
+        </div>
+    </div>
+
+</div>
+</main>
+<div th:replace="~{hodViewPages/hodfooter :: hodfooter}"></div>
+</div>
+
+<script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/hodViewPages/curriculum.html
+++ b/src/main/resources/templates/hodViewPages/curriculum.html
@@ -71,6 +71,7 @@
                             <tr>
                                 <th>#</th>
                                 <th>Subject</th>
+                                <th>Assigned Teacher</th>
                                 <th style="width:90px;"></th>
                             </tr>
                             </thead>
@@ -78,6 +79,13 @@
                             <tr th:each="sub, stat : ${semSubjects}">
                                 <td th:text="${stat.count}" class="text-muted"></td>
                                 <td th:text="${sub.subjectName}"></td>
+                                <td>
+                                    <span th:if="${assignedTeachers != null and assignedTeachers.containsKey(sub.subjectId)}"
+                                          class="badge bg-secondary fw-normal"
+                                          th:text="${assignedTeachers[sub.subjectId]}"></span>
+                                    <span th:unless="${assignedTeachers != null and assignedTeachers.containsKey(sub.subjectId)}"
+                                          class="text-muted small">—</span>
+                                </td>
                                 <td>
                                     <form th:action="@{/hod/delete-subject}" method="post"
                                           th:data-name="${sub.subjectName}"

--- a/src/main/resources/templates/hodViewPages/department-files.html
+++ b/src/main/resources/templates/hodViewPages/department-files.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
+    <title>Department Files &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/HOD/portal.css}">
+</head>
+<body>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
+
+<div class="hod-page-content">
+<main>
+<div class="hod-container">
+
+    <div class="hod-page-header">
+        <h2 class="hod-page-header__title">Department Files</h2>
+    </div>
+
+    <div th:if="${files.empty}" class="alert alert-info">
+        No files have been uploaded in this department yet.
+    </div>
+
+    <div th:unless="${files.empty}">
+        <input type="search" id="fileSearch" class="form-control mb-3"
+               placeholder="Search by filename, uploader, course, subject&hellip;" style="max-width:420px;">
+
+        <div class="hod-table-card">
+            <div class="table-responsive">
+                <table id="filesTable" class="table table-hover mb-0 align-middle">
+                    <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>File Name</th>
+                        <th>Type</th>
+                        <th>Uploader</th>
+                        <th>Course</th>
+                        <th>Semester</th>
+                        <th>Subject</th>
+                        <th>Category</th>
+                        <th>Size</th>
+                        <th>Uploaded</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="file, stat : ${files}">
+                        <td th:text="${stat.count}" class="text-muted"></td>
+                        <td th:text="${file.fileName}" class="text-truncate" style="max-width:180px;"></td>
+                        <td>
+                            <span class="badge bg-secondary text-uppercase" th:text="${file.fileType}"></span>
+                        </td>
+                        <td th:text="${file.ownersName}"></td>
+                        <td th:text="${courseNames[file.courseId] ?: '—'}"></td>
+                        <td th:text="${semesterNames[file.semesterId] ?: '—'}"></td>
+                        <td th:text="${subjectNames[file.subjectId] ?: '—'}"></td>
+                        <td th:text="${file.fileRole}"></td>
+                        <td class="text-nowrap"
+                            th:text="${#numbers.formatDecimal(file.fileSize / 1024.0, 1, 'COMMA', 1, 'POINT')} + ' KB'"></td>
+                        <td class="text-nowrap text-muted"
+                            th:text="${#dates.format(file.uploadDate, 'dd MMM yyyy')}"></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <p class="text-muted small mt-2"
+           th:text="${files.size()} + ' file(s) total'"></p>
+    </div>
+
+</div>
+</main>
+<div th:replace="~{hodViewPages/hodfooter :: hodfooter}"></div>
+</div>
+
+<script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
+<script>
+    document.getElementById('fileSearch') && document.getElementById('fileSearch').addEventListener('input', function () {
+        const query = this.value.toLowerCase();
+        document.querySelectorAll('#filesTable tbody tr').forEach(function (row) {
+            row.style.display = row.textContent.toLowerCase().includes(query) ? '' : 'none';
+        });
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/hodViewPages/edit-announcement.html
+++ b/src/main/resources/templates/hodViewPages/edit-announcement.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
+    <title>Edit Announcement &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/HOD/portal.css}">
+</head>
+<body>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
+
+<div class="hod-page-content">
+<main>
+<div class="hod-container">
+
+    <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6">
+            <div class="hod-form-card">
+                <div class="hod-form-card__title">Edit Announcement</div>
+
+                <div th:if="${errorMessage}" class="alert alert-danger mb-3" th:text="${errorMessage}"></div>
+
+                <form th:action="@{/hod/update-announcement}" method="post">
+                    <input type="hidden" name="id" th:value="${announcement.id}">
+
+                    <div class="mb-3">
+                        <label for="title" class="form-label fw-semibold">Title</label>
+                        <input id="title" type="text" name="title" class="form-control"
+                               maxlength="200" required th:value="${announcement.title}">
+                    </div>
+
+                    <div class="mb-4">
+                        <label for="body" class="form-label fw-semibold">Message</label>
+                        <textarea id="body" name="body" class="form-control" rows="6"
+                                  required th:text="${announcement.body}"></textarea>
+                    </div>
+
+                    <div class="d-flex gap-2 flex-wrap">
+                        <button type="submit" class="btn btn-primary">Save Changes</button>
+                        <a th:href="@{/hod/announcements}" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+</div>
+</main>
+<div th:replace="~{hodViewPages/hodfooter :: hodfooter}"></div>
+</div>
+
+<script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/hodViewPages/hod.html
+++ b/src/main/resources/templates/hodViewPages/hod.html
@@ -41,6 +41,18 @@
             <div class="hod-stat-card__num" th:text="${totalCourses}">0</div>
             <div class="hod-stat-card__label">Courses</div>
         </div>
+        <div class="hod-stat-card">
+            <div class="hod-stat-card__num" th:text="${totalSubjects}">0</div>
+            <div class="hod-stat-card__label">Subjects</div>
+        </div>
+        <div class="hod-stat-card">
+            <div class="hod-stat-card__num" th:text="${totalFiles}">0</div>
+            <div class="hod-stat-card__label">Files Uploaded</div>
+        </div>
+        <div class="hod-stat-card">
+            <div class="hod-stat-card__num" th:text="${announcementCount}">0</div>
+            <div class="hod-stat-card__label">Announcements</div>
+        </div>
     </div>
 
     <!-- Quick Actions -->
@@ -76,10 +88,30 @@
             <div class="hod-action-card__title">Curriculum</div>
             <div class="hod-action-card__desc">View the full subject grid per semester</div>
         </a>
+        <a th:href="@{/hod/assign-teachers}" class="hod-action-card">
+            <div class="hod-action-card__icon">&#128104;&#8203;&#127979;</div>
+            <div class="hod-action-card__title">Assign Teachers</div>
+            <div class="hod-action-card__desc">Designate which teacher teaches each subject</div>
+        </a>
+        <a th:href="@{/hod/workload}" class="hod-action-card">
+            <div class="hod-action-card__icon">&#128203;</div>
+            <div class="hod-action-card__title">Workload</div>
+            <div class="hod-action-card__desc">See subject assignments per teacher</div>
+        </a>
         <a th:href="@{/hod/members}" class="hod-action-card">
             <div class="hod-action-card__icon">&#128101;</div>
             <div class="hod-action-card__title">Members</div>
             <div class="hod-action-card__desc">View faculty and students in your department</div>
+        </a>
+        <a th:href="@{/hod/department-files}" class="hod-action-card">
+            <div class="hod-action-card__icon">&#128449;</div>
+            <div class="hod-action-card__title">Files</div>
+            <div class="hod-action-card__desc">Browse all resources uploaded in your department</div>
+        </a>
+        <a th:href="@{/hod/announcements}" class="hod-action-card">
+            <div class="hod-action-card__icon">&#128226;</div>
+            <div class="hod-action-card__title">Announcements</div>
+            <div class="hod-action-card__desc">Post notices to faculty and students</div>
         </a>
     </div>
 

--- a/src/main/resources/templates/hodViewPages/hodsidebar.html
+++ b/src/main/resources/templates/hodViewPages/hodsidebar.html
@@ -71,7 +71,8 @@
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle"
                            th:classappend="${currentUri.startsWith('/hod/add-subject') or
-                                            currentUri.startsWith('/hod/manage-subject')} ? ' is-active'"
+                                            currentUri.startsWith('/hod/manage-subject') or
+                                            currentUri.startsWith('/hod/assign-teachers')} ? ' is-active'"
                            href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Subjects
                         </a>
@@ -86,6 +87,12 @@
                                    th:classappend="${currentUri.startsWith('/hod/manage-subject')} ? ' is-active'"
                                    th:href="@{/hod/manage-subject}">Manage Subjects</a>
                             </li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                <a class="dropdown-item"
+                                   th:classappend="${currentUri.startsWith('/hod/assign-teachers')} ? ' is-active'"
+                                   th:href="@{/hod/assign-teachers}">Assign Teachers</a>
+                            </li>
                         </ul>
                     </li>
 
@@ -94,6 +101,27 @@
                         <a class="nav-link"
                            th:classappend="${currentUri.startsWith('/hod/members')} ? ' is-active'"
                            th:href="@{/hod/members}">Members</a>
+                    </li>
+
+                    <!-- Workload link -->
+                    <li class="nav-item">
+                        <a class="nav-link"
+                           th:classappend="${currentUri.startsWith('/hod/workload')} ? ' is-active'"
+                           th:href="@{/hod/workload}">Workload</a>
+                    </li>
+
+                    <!-- Files link -->
+                    <li class="nav-item">
+                        <a class="nav-link"
+                           th:classappend="${currentUri.startsWith('/hod/department-files')} ? ' is-active'"
+                           th:href="@{/hod/department-files}">Files</a>
+                    </li>
+
+                    <!-- Announcements link -->
+                    <li class="nav-item">
+                        <a class="nav-link"
+                           th:classappend="${currentUri.startsWith('/hod/announcements')} ? ' is-active'"
+                           th:href="@{/hod/announcements}">Announcements</a>
                     </li>
 
                 </ul>

--- a/src/main/resources/templates/hodViewPages/manage-semester.html
+++ b/src/main/resources/templates/hodViewPages/manage-semester.html
@@ -62,6 +62,7 @@
                     <tr>
                         <th>#</th>
                         <th>Semester Name</th>
+                        <th style="min-width:240px;">Rename</th>
                         <th style="width:90px;">Delete</th>
                     </tr>
                     </thead>
@@ -69,6 +70,15 @@
                     <tr th:each="sem, stat : ${semesters}">
                         <td th:text="${stat.count}" class="text-muted"></td>
                         <td th:text="${sem.semesterName}"></td>
+                        <td>
+                            <form th:action="@{/hod/update-semester}" method="post" class="d-flex gap-1">
+                                <input type="hidden" name="semesterId" th:value="${sem.semesterId}">
+                                <input type="hidden" name="courseId"   th:value="${course.courseId}">
+                                <input type="text" name="semesterName" th:value="${sem.semesterName}"
+                                       class="form-control form-control-sm" required>
+                                <button type="submit" class="btn btn-sm btn-success text-nowrap">Save</button>
+                            </form>
+                        </td>
                         <td>
                             <form th:action="@{/hod/delete-semester}" method="post"
                                   th:data-name="${sem.semesterName}"

--- a/src/main/resources/templates/hodViewPages/members.html
+++ b/src/main/resources/templates/hodViewPages/members.html
@@ -25,31 +25,34 @@
 
     <div th:if="${faculty.empty}" class="text-muted small mb-4">No faculty assigned to this department yet.</div>
 
-    <div th:unless="${faculty.empty}" class="hod-table-card mb-5">
-        <div class="table-responsive">
-            <table class="table table-hover mb-0 align-middle">
-                <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Username</th>
-                    <th>Email</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="member, stat : ${faculty}">
-                    <td th:text="${stat.count}" class="text-muted"></td>
-                    <td th:text="${member.userId}"></td>
-                    <td>
-                        <a th:if="${member.email != null and not #strings.isEmpty(member.email)}"
-                           th:href="'mailto:' + ${member.email}"
-                           th:text="${member.email}"
-                           style="color: var(--clr-primary);"></a>
-                        <span th:unless="${member.email != null and not #strings.isEmpty(member.email)}"
-                              class="text-muted">—</span>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
+    <div th:unless="${faculty.empty}" class="mb-5">
+        <input type="search" id="facultySearch" class="form-control mb-2" placeholder="Search faculty by username or email&hellip;" style="max-width:360px;">
+        <div class="hod-table-card">
+            <div class="table-responsive">
+                <table id="facultyTable" class="table table-hover mb-0 align-middle">
+                    <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Username</th>
+                        <th>Email</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="member, stat : ${faculty}">
+                        <td th:text="${stat.count}" class="text-muted"></td>
+                        <td th:text="${member.userId}"></td>
+                        <td>
+                            <a th:if="${member.email != null and not #strings.isEmpty(member.email)}"
+                               th:href="'mailto:' + ${member.email}"
+                               th:text="${member.email}"
+                               style="color: var(--clr-primary);"></a>
+                            <span th:unless="${member.email != null and not #strings.isEmpty(member.email)}"
+                                  class="text-muted">—</span>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 
@@ -58,31 +61,34 @@
 
     <div th:if="${students.empty}" class="text-muted small mb-4">No students assigned to this department yet.</div>
 
-    <div th:unless="${students.empty}" class="hod-table-card mb-5">
-        <div class="table-responsive">
-            <table class="table table-hover mb-0 align-middle">
-                <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Username</th>
-                    <th>Email</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="member, stat : ${students}">
-                    <td th:text="${stat.count}" class="text-muted"></td>
-                    <td th:text="${member.userId}"></td>
-                    <td>
-                        <a th:if="${member.email != null and not #strings.isEmpty(member.email)}"
-                           th:href="'mailto:' + ${member.email}"
-                           th:text="${member.email}"
-                           style="color: var(--clr-primary);"></a>
-                        <span th:unless="${member.email != null and not #strings.isEmpty(member.email)}"
-                              class="text-muted">—</span>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
+    <div th:unless="${students.empty}" class="mb-5">
+        <input type="search" id="studentSearch" class="form-control mb-2" placeholder="Search students by username or email&hellip;" style="max-width:360px;">
+        <div class="hod-table-card">
+            <div class="table-responsive">
+                <table id="studentTable" class="table table-hover mb-0 align-middle">
+                    <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Username</th>
+                        <th>Email</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="member, stat : ${students}">
+                        <td th:text="${stat.count}" class="text-muted"></td>
+                        <td th:text="${member.userId}"></td>
+                        <td>
+                            <a th:if="${member.email != null and not #strings.isEmpty(member.email)}"
+                               th:href="'mailto:' + ${member.email}"
+                               th:text="${member.email}"
+                               style="color: var(--clr-primary);"></a>
+                            <span th:unless="${member.email != null and not #strings.isEmpty(member.email)}"
+                                  class="text-muted">—</span>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 
@@ -92,5 +98,18 @@
 </div>
 
 <script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
+<script>
+    function filterTable(inputId, tableId) {
+        document.getElementById(inputId).addEventListener('input', function () {
+            const query = this.value.toLowerCase();
+            document.querySelectorAll('#' + tableId + ' tbody tr').forEach(function (row) {
+                const text = row.textContent.toLowerCase();
+                row.style.display = text.includes(query) ? '' : 'none';
+            });
+        });
+    }
+    filterTable('facultySearch', 'facultyTable');
+    filterTable('studentSearch', 'studentTable');
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/hodViewPages/workload.html
+++ b/src/main/resources/templates/hodViewPages/workload.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" th:href="@{/images/main-logo-black.jpeg}" type="image/png">
+    <title>Teacher Workload &mdash; CampusConnect</title>
+    <link rel="stylesheet" th:href="@{/vendor/bootstrap/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/CSS/theme.css}">
+    <link rel="stylesheet" th:href="@{/CSS/HOD/portal.css}">
+</head>
+<body>
+<div th:replace="~{hodViewPages/hodsidebar :: hodsidebar}"></div>
+
+<div class="hod-page-content">
+<main>
+<div class="hod-container">
+
+    <div class="hod-page-header">
+        <h2 class="hod-page-header__title">Teacher Workload</h2>
+        <a th:href="@{/hod/assign-teachers}" class="btn btn-primary btn-sm">Assign Teachers</a>
+    </div>
+
+    <div th:if="${teachers.empty}" class="alert alert-info">
+        No teachers are assigned to this department yet.
+    </div>
+
+    <div th:unless="${teachers.empty}" class="hod-table-card">
+        <div class="table-responsive">
+            <table class="table table-hover mb-0 align-middle">
+                <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Teacher</th>
+                    <th>Email</th>
+                    <th>Assigned Subjects</th>
+                    <th class="text-center">Count</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="teacher, stat : ${teachers}">
+                    <td th:text="${stat.count}" class="text-muted"></td>
+                    <td th:text="${teacher.userId}"></td>
+                    <td>
+                        <a th:if="${teacher.email != null and not #strings.isEmpty(teacher.email)}"
+                           th:href="'mailto:' + ${teacher.email}"
+                           th:text="${teacher.email}"
+                           style="color:var(--clr-primary);"></a>
+                        <span th:unless="${teacher.email != null and not #strings.isEmpty(teacher.email)}"
+                              class="text-muted">—</span>
+                    </td>
+                    <td>
+                        <th:block th:with="subjects=${assignmentsByTeacher[teacher.userId]}">
+                            <span th:if="${subjects == null or subjects.empty}" class="text-muted small">No subjects assigned</span>
+                            <div th:unless="${subjects == null or subjects.empty}">
+                                <span th:each="s, idx : ${subjects}"
+                                      class="badge bg-secondary me-1 mb-1"
+                                      th:text="${s.subjectName}"></span>
+                            </div>
+                        </th:block>
+                    </td>
+                    <td class="text-center">
+                        <th:block th:with="subjects=${assignmentsByTeacher[teacher.userId]}">
+                            <span th:text="${subjects != null ? subjects.size() : 0}"
+                                  class="badge"
+                                  th:classappend="${(subjects != null ? subjects.size() : 0) == 0} ? 'bg-light text-muted' : 'bg-primary'"></span>
+                        </th:block>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+</div>
+</main>
+<div th:replace="~{hodViewPages/hodfooter :: hodfooter}"></div>
+</div>
+
+<script th:src="@{/vendor/bootstrap/bootstrap.bundle.min.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/studentViewPages/indexstudent.html
+++ b/src/main/resources/templates/studentViewPages/indexstudent.html
@@ -71,6 +71,22 @@
 
     </div>
 
+    <!-- Department Announcements -->
+    <div th:if="${announcements != null and not announcements.empty}" class="student-container mt-2 mb-4">
+        <h6 style="font-size:0.7rem; font-weight:700; letter-spacing:0.1em; text-transform:uppercase;
+                   color:var(--clr-text-muted); margin-bottom:1rem; padding-bottom:0.4rem;
+                   border-bottom:1px solid var(--clr-border);">Department Announcements</h6>
+        <div th:each="ann : ${announcements}"
+             style="border:1px solid var(--clr-border); border-radius:var(--radius-md);
+                    background:var(--clr-surface); padding:1rem 1.25rem; margin-bottom:0.75rem;">
+            <div style="font-weight:600; margin-bottom:0.25rem;" th:text="${ann.title}"></div>
+            <div style="font-size:0.88rem; color:var(--clr-text); white-space:pre-wrap; margin-bottom:0.4rem;"
+                 th:text="${ann.body}"></div>
+            <small style="color:var(--clr-text-muted);"
+                   th:text="${#dates.format(ann.createdAt, 'dd MMM yyyy')}"></small>
+        </div>
+    </div>
+
 </div>
 <footer class="student-footer" th:text="'&copy; ' + ${currentYear} + ' CampusConnect'"></footer>
 

--- a/src/main/resources/templates/teacherViewPages/indexteacher.html
+++ b/src/main/resources/templates/teacherViewPages/indexteacher.html
@@ -98,6 +98,22 @@
 
     </div>
 
+    <!-- Department Announcements -->
+    <div th:if="${announcements != null and not announcements.empty}" class="mt-4">
+        <p style="font-size:0.7rem; font-weight:700; letter-spacing:0.1em; text-transform:uppercase;
+                  color:var(--clr-text-muted); margin-bottom:0.75rem; padding-bottom:0.4rem;
+                  border-bottom:1px solid var(--clr-border);">Department Announcements</p>
+        <div th:each="ann : ${announcements}"
+             style="border:1px solid var(--clr-border); border-radius:var(--radius-md);
+                    background:var(--clr-surface); padding:1rem 1.25rem; margin-bottom:0.75rem;">
+            <div style="font-weight:600; margin-bottom:0.25rem;" th:text="${ann.title}"></div>
+            <div style="font-size:0.88rem; color:var(--clr-text); white-space:pre-wrap; margin-bottom:0.4rem;"
+                 th:text="${ann.body}"></div>
+            <small style="color:var(--clr-text-muted);"
+                   th:text="${#dates.format(ann.createdAt, 'dd MMM yyyy')}"></small>
+        </div>
+    </div>
+
 </div>
 </main>
 <footer class="teacher-footer" th:text="'&copy; ' + ${currentYear} + ' CampusConnect'"></footer>


### PR DESCRIPTION
## Summary

- **SQL**: Added `announcements` and `teacher_subject` tables; fixed charset mismatch on FK columns
- **Entities/Repository**: `Announcement` and `TeacherSubject` entities with JPA DAOs
- **Service**: Announcement CRUD, teacher-subject assignment, and academic-integrity operations
- **HOD controller**: Teacher assignment, announcements CRUD, semester rename, curriculum management, and dashboard enhancements; refactored `ownsCourse` to accept `hodDeptId` to eliminate redundant `getLoggedInUser()` DB calls across 12 call sites
- **HOD templates**: Dedicated announcement edit page (`/hod/edit-announcement`) replacing the inline Bootstrap collapse form; announcement display on student and teacher home dashboards
- **Admin fix**: Added hidden `id` field to `add-user.html` — its absence caused `members.id NOT NULL` constraint violations on every user update

## Test plan

- [ ] Run `mvn test` — full suite green
- [ ] Log in as HOD; create, edit (via dedicated page), and delete an announcement
- [ ] Log in as student/teacher; confirm department announcements appear on the home dashboard
- [ ] Log in as admin; create a user, then edit and change their department — confirm no 500 error
- [ ] Log in as HOD; assign and remove a teacher from a subject; verify ownership guard rejects cross-department attempts