### PR TITLE
feat: Flyway migrations, Actuator health, HOD test coverage, and user manual

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,7 @@ EXPOSE 8080
 
 ENV UPLOAD_DIR=/uploads/
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://localhost:8080/actuator/health || exit 1
+
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
     volumes:
       - mysql_data:/var/lib/mysql
-      - ./sql-scripts/databaseScript.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "campusConnect", "-p${DB_PASSWORD}"]
       interval: 10s

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1,0 +1,200 @@
+# CampusConnect — User Manual
+
+## Overview
+
+CampusConnect is a role-based collaborative learning platform for academic institutions. There are four roles: **Admin**, **HOD** (Head of Department), **Teacher**, and **Student**. Each role has a dedicated dashboard and a set of permitted actions.
+
+**Default credentials** (password `password` for all dummy accounts):
+
+| Username | Role    |
+|----------|---------|
+| admin1   | Admin   |
+| admin2   | Admin   |
+| hod1     | HOD     |
+| hod2     | HOD     |
+| teacher1 | Teacher |
+| teacher2 | Teacher |
+| student1 | Student |
+| student2 | Student |
+
+---
+
+## Admin
+
+### Dashboard
+
+Displays total counts of users, departments, and courses registered in the system. Cards link to the corresponding management pages.
+
+### Manage Users
+
+**View:** `/admin/user-management` lists all registered users with their department and role.
+
+**Add a user:**
+1. Click **Add User**.
+2. Fill in username, email, password, role, and department.
+3. Click **Save**. The password is stored with the `{noop}` dev prefix automatically.
+
+**Edit a user:**
+1. Click the **Edit** icon next to a user.
+2. Update email, department, or role. Leave the password field blank to keep the existing password.
+3. Click **Save**.
+
+**Delete a user:**
+1. Click the **Delete** icon and confirm.
+2. Deletion fails with an error if the user has associated records (e.g., uploaded files).
+
+### Manage Departments
+
+**View:** `/admin/manage-department` lists all departments.
+
+**Add a department:**
+1. Click **Add Department** and enter a unique name.
+2. Click **Save**.
+
+**Delete a department:**
+- Deletion is blocked if the department has members or courses.
+
+### Profile
+
+- **View:** `/admin/profile` shows the current admin's username, department, and email.
+- **Edit email:** Update the email field and click **Save Changes**.
+- **Change password:** Fill in **New Password** and **Confirm Password** and click **Save Changes**. Leave both blank to keep the current password. Passwords must match.
+
+---
+
+## HOD (Head of Department)
+
+The HOD manages the curriculum, members, and announcements for their own department. All data is automatically scoped to the HOD's department — they cannot view or modify other departments.
+
+### Dashboard
+
+Displays the department name, total faculty, total students, and total courses.
+
+### Courses
+
+**Add a course:** `/admin/add-course` → enter a course name → Save. You are redirected to the semester setup page for the new course.
+
+**Manage courses:** `/hod/manage-course` lists courses. Use **Edit** to rename or **Delete** to remove (deletion blocked if the course has semesters).
+
+### Semesters
+
+**View:** `/hod/semesters?courseId=<id>` lists semesters for a course.
+
+**Add:** Enter a semester name in the inline form and click **Add**.
+
+**Rename:** Click **Edit** next to a semester, change the name, and click **Save**.
+
+**Delete:** Click **Delete** — blocked if the semester has subjects.
+
+### Curriculum
+
+`/hod/curriculum?courseId=<id>` shows all semesters and their subjects in one page.
+
+**Add a subject:** Enter the subject name under the correct semester row and click **Add Subject**.
+
+**Remove a subject:** Click the **Remove** button next to a subject.
+
+### Manage Subjects
+
+`/hod/manage-subject?courseId=<id>` provides a table view of all subjects grouped by semester.
+
+**Rename a subject:** Click **Edit**, update the name, click **Save**.
+
+**Delete a subject:** Click **Delete** — this also removes any teacher assignment for that subject.
+
+### Assign Teachers
+
+`/hod/assign-teachers?courseId=<id>` shows each subject with its currently assigned teacher.
+
+**Assign:** Select a teacher from the dropdown and click **Assign**.
+
+**Remove assignment:** Select the blank option and click **Assign**.
+
+Only teachers in the same department appear in the dropdown.
+
+### Department Files
+
+`/hod/department-files` shows all files uploaded by teachers in the department, with course, semester, subject, uploader, and upload date.
+
+### Members
+
+`/hod/members` lists all faculty and students registered in the department.
+
+### Announcements
+
+**View:** `/hod/announcements` lists all department announcements.
+
+**Post:** Fill in the title and body in the inline form and click **Post Announcement**.
+
+**Edit:** Click **Edit** next to an announcement, update the fields, and click **Update**.
+
+**Delete:** Click **Delete** next to an announcement.
+
+### Profile
+
+Same as Admin profile — update email and/or password from `/hod/profile`.
+
+---
+
+## Teacher
+
+The Teacher can upload and browse learning resources scoped to the courses they are assigned to teach.
+
+### Dashboard
+
+`/teacher` shows quick-access cards for each resource category (PPTs, Notes, Programs, Audio Books, Reference Books, Videos). Announcements from the teacher's department appear below.
+
+### Upload Resources
+
+`/teacher/upload` (or the category-specific links)
+
+1. Select **Course**, **Semester**, **Subject**, and **Category**.
+   - Only courses, semesters, and subjects from the teacher's own assignments appear.
+2. Click **Choose File** and select the file to upload.
+3. Click **Upload**. The file is saved to the server and recorded in the database.
+
+Attempting to upload for a subject you are not assigned to returns an error.
+
+### Browse Resources
+
+`/teacher/browse` lets the teacher search for files uploaded by anyone in their department.
+
+1. Optionally filter by **Category**, **Course**, **Semester**, or **Subject**.
+2. Click **Search**.
+3. Download in the original format, GZIP-compressed, or ZIP-compressed using the buttons in the results table.
+
+### Profile
+
+`/teacher/profile` — update email and/or password. Same interaction as Admin and HOD.
+
+---
+
+## Student
+
+Students can browse and download resources uploaded by teachers in their department. They cannot upload files.
+
+### Dashboard
+
+`/student` shows resource-category cards and department announcements. Click a card to go directly to the browse page filtered to that category.
+
+### Browse Resources
+
+`/student/browse`
+
+1. The **Department** field is pre-filled and read-only (students are always scoped to their own department).
+2. Optionally filter by **Category**, **Course**, **Semester**, or **Subject**.
+3. Click **Search**.
+4. The results table shows matching files. Click **Original**, **GZIP**, or **ZIP** to download.
+
+### Profile
+
+`/student/profile` — update email and/or change password. Leave the password fields blank to keep the current password. Both fields must match to change the password.
+
+---
+
+## Common Notes
+
+- **Session:** You are automatically logged out after closing the browser (session-based authentication). Use the **Logout** button in the header to end your session explicitly.
+- **File size:** Single-file uploads are capped at 1 GB. Reduce files before uploading if needed.
+- **Supported files:** Any file type is accepted; the category (PPTs, Notes, etc.) is chosen by the uploader.
+- **Password storage:** Passwords are stored with a `{noop}` prefix in development mode (plain-text). This is intentional for a demo environment and must be replaced with BCrypt in production.

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,14 @@
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-springsecurity6</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,15 @@ file.upload-dir=${UPLOAD_DIR:uploads/}
 
 #spring.jpa.hibernate.ddl-auto=update
 
+# Flyway — runs V1+V2 on a fresh DB; on an existing DB with no flyway history, baselines at V2
+# so future migrations (V3+) apply without re-running the initial schema/seed.
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=2
+
+# Actuator — expose only the health endpoint
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never
+
 # Max file size limit
 spring.servlet.multipart.max-file-size=1000000MB
 spring.servlet.multipart.max-request-size=1000000MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,10 +13,6 @@ file.upload-dir=${UPLOAD_DIR:uploads/}
 
 #spring.jpa.hibernate.ddl-auto=update
 
-# Flyway — runs V1+V2 on a fresh DB; on an existing DB with no flyway history, baselines at V2
-# so future migrations (V3+) apply without re-running the initial schema/seed.
-spring.flyway.baseline-on-migrate=true
-spring.flyway.baseline-version=2
 
 # Actuator — expose only the health endpoint
 management.endpoints.web.exposure.include=health

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,145 @@
+-- CampusConnect initial schema — all DDL in FK dependency order.
+-- Applied once by Flyway on first boot against an empty database.
+
+CREATE TABLE IF NOT EXISTS `department`
+(
+    `department_id`   INT         NOT NULL AUTO_INCREMENT,
+    `department_name` VARCHAR(50) NOT NULL,
+    PRIMARY KEY (`department_id`),
+    UNIQUE KEY `department_name` (`department_name`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `members`
+(
+    `id`         INT          NOT NULL AUTO_INCREMENT,
+    `user_id`    VARCHAR(50)  NOT NULL,
+    `email`      VARCHAR(255) NOT NULL,
+    `pw`         CHAR(68)     NOT NULL,
+    `active`     TINYINT      NOT NULL,
+    `department` VARCHAR(100) NOT NULL,
+    `dept_id`    INT,
+    PRIMARY KEY (`user_id`),
+    UNIQUE KEY `id` (`id`),
+    UNIQUE KEY `email` (`email`),
+    FOREIGN KEY (`dept_id`) REFERENCES `department` (`department_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `roles`
+(
+    `user_id` VARCHAR(50) NOT NULL,
+    `role`    VARCHAR(50) NOT NULL,
+    PRIMARY KEY (`user_id`),
+    CONSTRAINT `fk_user_roles` FOREIGN KEY (`user_id`) REFERENCES `members` (`user_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `department_details`
+(
+    `department_member_id` INT         NOT NULL AUTO_INCREMENT,
+    `department_id`        INT         NOT NULL,
+    `user_name`            VARCHAR(50) NOT NULL,
+    `role`                 VARCHAR(50) NOT NULL,
+    PRIMARY KEY (`department_member_id`),
+    UNIQUE KEY `user_name` (`user_name`),
+    KEY `department_id` (`department_id`),
+    CONSTRAINT `fk_department` FOREIGN KEY (`department_id`) REFERENCES `department` (`department_id`),
+    CONSTRAINT `fk_member`     FOREIGN KEY (`user_name`)     REFERENCES `members`    (`user_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `course_details`
+(
+    `course_id`     INT          NOT NULL AUTO_INCREMENT,
+    `course_name`   VARCHAR(100) NOT NULL,
+    `department_id` INT          NOT NULL,
+    PRIMARY KEY (`course_id`),
+    CONSTRAINT `fk_department_course` FOREIGN KEY (`department_id`) REFERENCES `department` (`department_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `semester`
+(
+    `semester_id`   INT         NOT NULL AUTO_INCREMENT,
+    `semester_name` VARCHAR(50) NOT NULL,
+    `course_id`     INT         NOT NULL,
+    PRIMARY KEY (`semester_id`),
+    CONSTRAINT `fk_course_semester` FOREIGN KEY (`course_id`) REFERENCES `course_details` (`course_id`) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `subject_details`
+(
+    `subject_id`   INT          NOT NULL AUTO_INCREMENT,
+    `subject_name` VARCHAR(100) NOT NULL,
+    `course_id`    INT          NOT NULL,
+    `semester_id`  INT          NOT NULL,
+    PRIMARY KEY (`subject_id`),
+    CONSTRAINT `fk_course_subject`   FOREIGN KEY (`course_id`)   REFERENCES `course_details` (`course_id`),
+    CONSTRAINT `fk_semester_subject` FOREIGN KEY (`semester_id`) REFERENCES `semester`       (`semester_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `file_data`
+(
+    `file_id`                INT          NOT NULL AUTO_INCREMENT,
+    `file_name`              VARCHAR(255) NOT NULL,
+    `file_type`              VARCHAR(100) NOT NULL,
+    `file_path`              VARCHAR(255) NOT NULL,
+    `file_size`              BIGINT       NOT NULL,
+    `uploader_department_id` INT          NOT NULL,
+    `uploader_name`          VARCHAR(255) NOT NULL,
+    `course_id`              INT          NOT NULL,
+    `semester_id`            INT          NOT NULL,
+    `subject_id`             INT          NOT NULL,
+    `uploaded_at`            TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `file_role`              VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`file_id`),
+    KEY `department_id` (`uploader_department_id`),
+    KEY `course_id` (`course_id`),
+    KEY `semester_id` (`semester_id`),
+    KEY `subject_id` (`subject_id`),
+    CONSTRAINT `fk_department_file` FOREIGN KEY (`uploader_department_id`) REFERENCES `department`      (`department_id`),
+    CONSTRAINT `fk_course_file`     FOREIGN KEY (`course_id`)              REFERENCES `course_details`  (`course_id`),
+    CONSTRAINT `fk_semester_file`   FOREIGN KEY (`semester_id`)            REFERENCES `semester`        (`semester_id`),
+    CONSTRAINT `fk_subject_file`    FOREIGN KEY (`subject_id`)             REFERENCES `subject_details` (`subject_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `announcements`
+(
+    `id`         INT          NOT NULL AUTO_INCREMENT,
+    `dept_id`    INT          NOT NULL,
+    `author`     VARCHAR(50)  NOT NULL,
+    `title`      VARCHAR(200) NOT NULL,
+    `body`       TEXT         NOT NULL,
+    `created_at` TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    KEY `dept_id` (`dept_id`),
+    CONSTRAINT `fk_dept_announcement`   FOREIGN KEY (`dept_id`) REFERENCES `department` (`department_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `fk_author_announcement` FOREIGN KEY (`author`)  REFERENCES `members`    (`user_id`)       ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `teacher_subject`
+(
+    `id`         INT         NOT NULL AUTO_INCREMENT,
+    `teacher_id` VARCHAR(50) NOT NULL,
+    `subject_id` INT         NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uq_subject` (`subject_id`),
+    CONSTRAINT `fk_teacher_ts` FOREIGN KEY (`teacher_id`) REFERENCES `members`         (`user_id`)    ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `fk_subject_ts` FOREIGN KEY (`subject_id`) REFERENCES `subject_details` (`subject_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V2__seed_data.sql
+++ b/src/main/resources/db/migration/V2__seed_data.sql
@@ -1,0 +1,116 @@
+-- CampusConnect seed data — all dummy records for local/Docker development.
+-- Passwords stored as {noop}password (plain-text dev only; never use in production).
+
+INSERT INTO `department` VALUES
+    (1001, 'Computer Applications'),
+    (1002, 'Computer Science'),
+    (1003, 'Physics');
+
+INSERT INTO `members` VALUES
+    (1, 'hod1',     'hod1@campus.com',     '{noop}password', 1, 'Computer Applications', 1001),
+    (2, 'hod2',     'hod2@campus.com',     '{noop}password', 1, 'Computer Science',      1002),
+    (3, 'teacher1', 'teacher1@campus.com', '{noop}password', 1, 'Computer Applications', 1001),
+    (4, 'teacher2', 'teacher2@campus.com', '{noop}password', 1, 'Physics',               1003),
+    (5, 'student1', 'student1@campus.com', '{noop}password', 1, 'Computer Science',      1002),
+    (6, 'student2', 'student2@campus.com', '{noop}password', 1, 'Physics',               1003),
+    (7, 'admin1',   'admin1@campus.com',   '{noop}password', 1, 'Computer Applications', 1001),
+    (8, 'admin2',   'admin2@campus.com',   '{noop}password', 1, 'Physics',               1003);
+
+INSERT INTO `roles` VALUES
+    ('hod1',     'ROLE_HOD'),
+    ('hod2',     'ROLE_HOD'),
+    ('teacher1', 'ROLE_TEACHER'),
+    ('teacher2', 'ROLE_TEACHER'),
+    ('student1', 'ROLE_STUDENT'),
+    ('student2', 'ROLE_STUDENT'),
+    ('admin1',   'ROLE_ADMIN'),
+    ('admin2',   'ROLE_ADMIN');
+
+INSERT INTO `department_details` VALUES
+    (1, 1001, 'hod1',     'HOD'),
+    (2, 1002, 'hod2',     'HOD'),
+    (3, 1001, 'teacher1', 'TEACHER'),
+    (4, 1003, 'teacher2', 'TEACHER'),
+    (5, 1002, 'student1', 'STUDENT'),
+    (6, 1003, 'student2', 'STUDENT'),
+    (7, 1001, 'admin1',   'ADMIN'),
+    (8, 1003, 'admin2',   'ADMIN');
+
+-- Courses: one per department (HODs can add more at runtime)
+INSERT INTO `course_details` (`course_name`, `department_id`) VALUES
+    ('Bachelor of Computer Applications (BCA)',         1001),
+    ('Bachelor of Science in Computer Science (BSc CS)',1002),
+    ('Bachelor of Science in Physics (BSc Physics)',    1003);
+-- Auto-assigned course_id: 1 = BCA, 2 = BSc CS, 3 = BSc Physics
+
+-- Semesters: 6 per course
+INSERT INTO `semester` (`semester_name`, `course_id`) VALUES
+    -- BCA (course_id=1): semester_id 1-6
+    ('Semester I',   1), ('Semester II',  1), ('Semester III', 1),
+    ('Semester IV',  1), ('Semester V',   1), ('Semester VI',  1),
+    -- BSc CS (course_id=2): semester_id 7-12
+    ('Semester I',   2), ('Semester II',  2), ('Semester III', 2),
+    ('Semester IV',  2), ('Semester V',   2), ('Semester VI',  2),
+    -- BSc Physics (course_id=3): semester_id 13-18
+    ('Semester I',   3), ('Semester II',  3), ('Semester III', 3),
+    ('Semester IV',  3), ('Semester V',   3), ('Semester VI',  3);
+
+-- Subjects
+INSERT INTO `subject_details` (`subject_name`, `course_id`, `semester_id`) VALUES
+    -- BCA Sem I (course=1, sem=1)
+    ('Programming Fundamentals in C', 1, 1),
+    ('Mathematics I',                 1, 1),
+    ('English Communication',         1, 1),
+    ('Computer Fundamentals',         1, 1),
+    -- BCA Sem II (course=1, sem=2)
+    ('Data Structures',               1, 2),
+    ('Mathematics II',                1, 2),
+    ('Database Management',           1, 2),
+    ('Web Technologies',              1, 2),
+    -- BCA Sem III (course=1, sem=3)
+    ('Object-Oriented Programming with Java', 1, 3),
+    ('Operating Systems',                     1, 3),
+    ('Computer Networks',                     1, 3),
+    ('Software Engineering',                  1, 3),
+    -- BSc CS Sem I (course=2, sem=7)
+    ('C Programming',          2, 7),
+    ('Discrete Mathematics',   2, 7),
+    ('Computer Organization',  2, 7),
+    ('English for Science',    2, 7),
+    -- BSc CS Sem II (course=2, sem=8)
+    ('Data Structures and Algorithms', 2, 8),
+    ('Digital Electronics',            2, 8),
+    ('Probability and Statistics',     2, 8),
+    ('Python Programming',             2, 8),
+    -- BSc Physics Sem I (course=3, sem=13)
+    ('Classical Mechanics',  3, 13),
+    ('Thermodynamics',       3, 13),
+    ('Mathematical Physics', 3, 13),
+    ('Electronics Basics',   3, 13),
+    -- BSc Physics Sem II (course=3, sem=14)
+    ('Electromagnetism',     3, 14),
+    ('Waves and Optics',     3, 14),
+    ('Quantum Mechanics I',  3, 14),
+    ('Statistical Mechanics',3, 14);
+
+-- Announcements
+INSERT INTO `announcements` (`dept_id`, `author`, `title`, `body`) VALUES
+    (1001, 'hod1', 'Welcome to the New Academic Year',
+     'Welcome back, everyone! The new academic year begins this Monday. Please ensure all course materials are uploaded to CampusConnect by the end of the first week.'),
+    (1001, 'hod1', 'Internal Examination Schedule',
+     'Internal examinations for BCA Semester I will be held from the 3rd week of this month. Teachers are requested to share question banks with students at least one week before the exam.'),
+    (1002, 'hod2', 'Lab Schedule Update',
+     'The Computer Science lab sessions have been rescheduled. New timetables are available on the notice board. Please check with your faculty for updated slot assignments.');
+
+-- Teacher-subject assignments
+INSERT INTO `teacher_subject` (`teacher_id`, `subject_id`) VALUES
+    ('teacher1', 1),   -- Programming Fundamentals in C
+    ('teacher1', 2),   -- Mathematics I
+    ('teacher1', 5),   -- Data Structures
+    ('teacher1', 7),   -- Database Management
+    ('teacher1', 9),   -- Object-Oriented Programming with Java
+    ('teacher1', 11),  -- Computer Networks
+    ('teacher2', 21),  -- Classical Mechanics
+    ('teacher2', 22),  -- Thermodynamics
+    ('teacher2', 25),  -- Electromagnetism
+    ('teacher2', 26);  -- Waves and Optics

--- a/src/test/java/com/bitsunisage/campusconnect/controller/HodControllerTest.java
+++ b/src/test/java/com/bitsunisage/campusconnect/controller/HodControllerTest.java
@@ -1,10 +1,7 @@
 package com.bitsunisage.campusconnect.controller;
 
 import com.bitsunisage.campusconnect.config.TestWebConfig;
-import com.bitsunisage.campusconnect.entities.CourseDetails;
-import com.bitsunisage.campusconnect.entities.Semester;
-import com.bitsunisage.campusconnect.entities.SubjectDetails;
-import com.bitsunisage.campusconnect.entities.User;
+import com.bitsunisage.campusconnect.entities.*;
 import com.bitsunisage.campusconnect.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +14,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -332,5 +330,315 @@ class HodControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/hod/profile"))
                 .andExpect(flash().attributeExists("successMessage"));
+    }
+
+    // ── Semesters (write) ─────────────────────────────────────────────────────
+
+    @Test
+    void saveSemesterWithBlankNameRedirectsWithError() throws Exception {
+        mockMvc.perform(post("/hod/save-semester").with(csrf())
+                        .param("courseId", "1")
+                        .param("semesterName", "   "))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/semesters?courseId=1"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        verify(userService, never()).saveSemester(any());
+    }
+
+    @Test
+    void saveSemesterSuccessAddsNewSemesterAndRedirects() throws Exception {
+        when(userService.saveSemester(any())).thenReturn(new Semester());
+
+        mockMvc.perform(post("/hod/save-semester").with(csrf())
+                        .param("courseId", "1")
+                        .param("semesterName", "Semester V"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/semesters?courseId=1"))
+                .andExpect(flash().attributeExists("successMessage"));
+
+        verify(userService).saveSemester(any(Semester.class));
+    }
+
+    @Test
+    void deleteSemesterWithSubjectsAssignedRedirectsWithError() throws Exception {
+        when(userService.countSubjectsBySemester(1L)).thenReturn(3);
+
+        mockMvc.perform(post("/hod/delete-semester").with(csrf())
+                        .param("semesterId", "1")
+                        .param("courseId", "1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/semesters?courseId=1"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        verify(userService, never()).deleteSemester(any());
+    }
+
+    @Test
+    void deleteSemesterSuccessDeletesAndRedirects() throws Exception {
+        Semester sem = new Semester();
+        sem.setSemesterId(1L);
+        when(userService.countSubjectsBySemester(1L)).thenReturn(0);
+        when(userService.getSemesterById(1L)).thenReturn(sem);
+        doNothing().when(userService).deleteSemester(any());
+
+        mockMvc.perform(post("/hod/delete-semester").with(csrf())
+                        .param("semesterId", "1")
+                        .param("courseId", "1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/semesters?courseId=1"))
+                .andExpect(flash().attributeExists("successMessage"));
+
+        verify(userService).deleteSemester(sem);
+    }
+
+    @Test
+    void updateSemesterSuccessRenamesAndRedirects() throws Exception {
+        Semester existing = new Semester();
+        existing.setSemesterId(1L);
+        existing.setSemesterName("Semester I");
+        existing.setCourseId(1L);
+        when(userService.getSemesterById(1L)).thenReturn(existing);
+        when(userService.semesterNameExistsInCourse(anyLong(), anyString())).thenReturn(false);
+        when(userService.saveSemester(any())).thenReturn(existing);
+
+        mockMvc.perform(post("/hod/update-semester").with(csrf())
+                        .param("semesterId", "1")
+                        .param("semesterName", "Semester One")
+                        .param("courseId", "1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/semesters?courseId=1"))
+                .andExpect(flash().attributeExists("successMessage"));
+
+        verify(userService).saveSemester(existing);
+    }
+
+    // ── Subjects (write) ──────────────────────────────────────────────────────
+
+    @Test
+    void updateSubjectSuccessRedirectsToManageSubject() throws Exception {
+        SubjectDetails sub = new SubjectDetails();
+        sub.setSubjectId(1L);
+        sub.setSubjectName("Old Name");
+        sub.setCourseId(1);
+        when(userService.getSubjectById(1L)).thenReturn(sub);
+        when(userService.saveSubject(any())).thenReturn(sub);
+
+        mockMvc.perform(post("/hod/update-subject").with(csrf())
+                        .param("subjectId", "1")
+                        .param("subjectName", "Data Structures")
+                        .param("courseId", "1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/manage-subject?courseId=1"))
+                .andExpect(flash().attributeExists("successMessage"));
+
+        verify(userService).saveSubject(any(SubjectDetails.class));
+    }
+
+    // ── Teacher-Subject Assignment ────────────────────────────────────────────
+
+    @Test
+    void assignTeachersPageWithoutCourseIdShowsCourseSelector() throws Exception {
+        when(userService.getMembersByDepartmentAndRole(1001L, "TEACHER")).thenReturn(List.of());
+
+        mockMvc.perform(get("/hod/assign-teachers"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("hodViewPages/assign-teachers"))
+                .andExpect(model().attributeExists("courses", "teachers"))
+                .andExpect(model().attributeDoesNotExist("course"));
+    }
+
+    @Test
+    void assignTeachersPageWithCourseIdShowsSubjectsGroupedBySemester() throws Exception {
+        SubjectDetails sub = new SubjectDetails();
+        sub.setSubjectId(10L);
+        sub.setCourseId(1);
+        sub.setSemesterId(1);
+        when(userService.getMembersByDepartmentAndRole(1001L, "TEACHER")).thenReturn(List.of());
+        when(userService.getSubjectsByCourseId(1)).thenReturn(List.of(sub));
+        when(userService.getAssignmentsBySubjectIds(any())).thenReturn(List.of());
+        when(userService.getSemestersByCourseId(1L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/hod/assign-teachers").param("courseId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("hodViewPages/assign-teachers"))
+                .andExpect(model().attributeExists("course", "subjectsBySemester", "assignmentsBySubjectId"));
+    }
+
+    @Test
+    void assignTeacherWithTeacherIdSavesAssignmentAndRedirects() throws Exception {
+        User teacher = new User();
+        teacher.setUserId("teacher1");
+        teacher.setDeptID(1001L);
+        when(userService.findUserByUserId("teacher1")).thenReturn(teacher);
+        doNothing().when(userService).upsertTeacherAssignment(anyString(), anyLong());
+
+        mockMvc.perform(post("/hod/assign-teacher").with(csrf())
+                        .param("subjectId", "10")
+                        .param("teacherId", "teacher1")
+                        .param("courseId", "1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/assign-teachers?courseId=1"))
+                .andExpect(flash().attributeExists("successMessage"));
+
+        verify(userService).upsertTeacherAssignment("teacher1", 10L);
+    }
+
+    @Test
+    void assignTeacherWithBlankTeacherIdRemovesAssignmentAndRedirects() throws Exception {
+        doNothing().when(userService).removeTeacherAssignmentBySubjectId(anyLong());
+
+        mockMvc.perform(post("/hod/assign-teacher").with(csrf())
+                        .param("subjectId", "10")
+                        .param("courseId", "1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/assign-teachers?courseId=1"));
+
+        verify(userService).removeTeacherAssignmentBySubjectId(10L);
+    }
+
+    // ── Department Files ──────────────────────────────────────────────────────
+
+    @Test
+    void departmentFilesPagePopulatesFilesAndLookupMaps() throws Exception {
+        FileData file = new FileData();
+        file.setId(1L);
+        file.setCourseId(1L);
+        file.setSemesterId(1L);
+        file.setSubjectId(1L);
+        when(userService.getFilesByDepartmentId(1001L)).thenReturn(List.of(file));
+        when(userService.getCourseName(any())).thenReturn(List.of());
+        when(userService.getSemesterName(any())).thenReturn(List.of());
+        when(userService.getSubjectName(any())).thenReturn(List.of());
+
+        mockMvc.perform(get("/hod/department-files"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("hodViewPages/department-files"))
+                .andExpect(model().attributeExists("files", "courseNames", "semesterNames", "subjectNames"));
+    }
+
+    // ── Announcements ─────────────────────────────────────────────────────────
+
+    @Test
+    void announcementsPageListsDeptAnnouncements() throws Exception {
+        Announcement a = new Announcement();
+        a.setId(1L);
+        a.setDeptId(1001L);
+        a.setTitle("Welcome");
+        when(userService.getAnnouncementsByDeptId(1001L)).thenReturn(List.of(a));
+
+        mockMvc.perform(get("/hod/announcements"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("hodViewPages/announcements"))
+                .andExpect(model().attributeExists("announcements"));
+    }
+
+    @Test
+    void editAnnouncementPageLoadsForOwnedAnnouncement() throws Exception {
+        Announcement a = new Announcement();
+        a.setId(1L);
+        a.setDeptId(1001L);
+        a.setTitle("Test");
+        a.setBody("Body text");
+        when(userService.getAnnouncementById(1L)).thenReturn(Optional.of(a));
+
+        mockMvc.perform(get("/hod/edit-announcement").param("id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("hodViewPages/edit-announcement"))
+                .andExpect(model().attributeExists("announcement"));
+    }
+
+    @Test
+    void editAnnouncementForUnknownIdRedirectsWithError() throws Exception {
+        when(userService.getAnnouncementById(99L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/hod/edit-announcement").param("id", "99"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/announcements"))
+                .andExpect(flash().attributeExists("errorMessage"));
+    }
+
+    @Test
+    void saveAnnouncementCreatesAndRedirectsWithSuccess() throws Exception {
+        when(userService.saveAnnouncement(any())).thenReturn(new Announcement());
+
+        mockMvc.perform(post("/hod/save-announcement").with(csrf())
+                        .param("title", "Exam Schedule Released")
+                        .param("body", "Please check the notice board."))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/announcements"))
+                .andExpect(flash().attributeExists("successMessage"));
+
+        verify(userService).saveAnnouncement(any(Announcement.class));
+    }
+
+    @Test
+    void deleteAnnouncementDeletesOwnedAnnouncementAndRedirects() throws Exception {
+        Announcement a = new Announcement();
+        a.setId(1L);
+        a.setDeptId(1001L);
+        when(userService.getAnnouncementById(1L)).thenReturn(Optional.of(a));
+        doNothing().when(userService).deleteAnnouncementById(1L);
+
+        mockMvc.perform(post("/hod/delete-announcement").with(csrf()).param("id", "1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/announcements"))
+                .andExpect(flash().attributeExists("successMessage"));
+
+        verify(userService).deleteAnnouncementById(1L);
+    }
+
+    @Test
+    void updateAnnouncementWithBlankFieldsRedirectsWithError() throws Exception {
+        mockMvc.perform(post("/hod/update-announcement").with(csrf())
+                        .param("id", "1")
+                        .param("title", "")
+                        .param("body", ""))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/announcements"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        verify(userService, never()).saveAnnouncement(any());
+    }
+
+    @Test
+    void updateAnnouncementSuccessUpdatesAndRedirects() throws Exception {
+        Announcement a = new Announcement();
+        a.setId(1L);
+        a.setDeptId(1001L);
+        a.setTitle("Old Title");
+        a.setBody("Old body");
+        when(userService.getAnnouncementById(1L)).thenReturn(Optional.of(a));
+        when(userService.saveAnnouncement(any())).thenReturn(a);
+
+        mockMvc.perform(post("/hod/update-announcement").with(csrf())
+                        .param("id", "1")
+                        .param("title", "Updated Title")
+                        .param("body", "Updated body text"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/hod/announcements"))
+                .andExpect(flash().attributeExists("successMessage"));
+
+        verify(userService).saveAnnouncement(any(Announcement.class));
+    }
+
+    // ── Workload ──────────────────────────────────────────────────────────────
+
+    @Test
+    void workloadPagePopulatesTeachersAndAssignments() throws Exception {
+        User teacher = new User();
+        teacher.setUserId("teacher1");
+        teacher.setDeptID(1001L);
+        TeacherSubject assignment = new TeacherSubject();
+        assignment.setTeacherId("teacher1");
+        assignment.setSubjectId(1L);
+        when(userService.getMembersByDepartmentAndRole(1001L, "TEACHER")).thenReturn(List.of(teacher));
+        when(userService.getAssignmentsByTeacherIds(any())).thenReturn(List.of(assignment));
+        when(userService.getSubjectName(any())).thenReturn(List.of());
+
+        mockMvc.perform(get("/hod/workload"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("hodViewPages/workload"))
+                .andExpect(model().attributeExists("teachers", "assignmentsByTeacher"));
     }
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -6,6 +6,9 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
+# Flyway uses MySQL-specific SQL; let JPA manage the H2 test schema instead
+spring.flyway.enabled=false
+
 file.upload-dir=uploads/
 
 spring.main.banner-mode=off


### PR DESCRIPTION
## Summary

- **HOD test coverage**: 19 new `@WebMvcTest` tests filling 13 previously untested routes (save/delete/update-semester, update-subject, assign-teachers, assign-teacher, department-files, announcements, edit/save/delete/update-announcement, workload). Suite: 194 tests, 0 failures.
- **Flyway**: `V1__init_schema.sql` (DDL) + `V2__seed_data.sql` (seed data) replace the manual SQL volume mount. Flyway owns the schema from V1 — on first boot against an empty database both migrations run automatically. Future schema changes go through versioned `V{n}` files.
- **Spring Boot Actuator**: `/actuator/health` endpoint exposed. Dockerfile `HEALTHCHECK` updated to probe it.
- **Docker**: SQL volume mount removed from `docker-compose.yml` — Flyway handles schema creation on app startup.
- **User manual**: `docs/USER_MANUAL.md` covering all four roles (Admin, HOD, Teacher, Student) with step-by-step instructions for every feature.

## Test plan

- [x] Merge triggers Railway redeploy
- [x] Flyway runs V1 + V2 on the fresh empty Railway database
- [x] App comes online at campuss-connect.up.railway.app
- [x] Login with dummy credentials (password: `password`) for each role and verify dashboard loads
- [x] `GET /actuator/health` returns `{"status":"UP"}`