### PR TITLE
feat: Flyway migrations, Actuator, HOD tests, and Railway deployment fix

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=CampusConnect
 
-spring.datasource.url=${DB_URL:jdbc:mysql://localhost:3306/campusConnect}
-spring.datasource.username=${DB_USERNAME:campusConnect}
-spring.datasource.password=${DB_PASSWORD}
+spring.datasource.url=${DB_URL:jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:campusConnect}?allowPublicKeyRetrieval=true&useSSL=false}
+spring.datasource.username=${DB_USERNAME:${MYSQL_USER:campusConnect}}
+spring.datasource.password=${DB_PASSWORD:${MYSQL_ROOT_PASSWORD:password}}
 
 
 spring.main.banner-mode=off


### PR DESCRIPTION
## Summary

- **Flyway migrations**: `V1__init_schema.sql` and `V2__seed_data.sql` replace the manual `databaseScript.sql` seed — schema and dummy data are applied automatically on startup in all environments
- **Spring Boot Actuator**: health endpoint exposed at `/actuator/health` for Railway and Docker healthchecks
- **HOD test coverage**: 19 new `@WebMvcTest` tests covering 13 previously untested routes
- **Railway deployment fix**: datasource config now resolves from Railway's auto-injected `MYSQL_*` variables as a fallback chain, removing the need to manually wire `DB_URL`/`DB_USERNAME`/`DB_PASSWORD` reference variables in Railway

## Test plan

- [ ] `mvn test` passes green locally
- [ ] Docker: `docker compose up` starts app and db cleanly; Flyway runs both migrations on a fresh volume
- [ ] Railway: deploy from this branch, confirm app starts without DB connection errors after deleting the manual `DB_*` variables from the CampusConnect service