### PR TITLE
docs: overhaul all documentation and add CONTRIBUTING guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,28 +1,64 @@
 ---
-name: issue_template
-about: Describe this issue template's purpose here.
-title: ''
+name: Issue / Feature Request
+about: Report a bug, request a feature, or describe a user story
+title: '[TYPE] Short description'
 labels: ''
 assignees: ''
 
 ---
 
-### User Story
+### Type
 
-**Title:** 
+<!-- Check one -->
+- [ ] Bug report
+- [ ] Feature request
+- [ ] User story
+- [ ] Documentation
 
-**As a** _______
+---
 
-**I want to** ____________
+### User Story *(for features and enhancements)*
 
-**So that** _______
+**As a** *(Admin / HOD / Teacher / Student)*
 
-**Acceptance Criteria:**
+**I want to** *(describe the action)*
 
-- **Given**  
-  **When**   
-  **Then**   
+**So that** *(describe the benefit)*
 
-- **Given**   
-  **When**   
+---
+
+### Acceptance Criteria
+
+- **Given** *(precondition)*
+  **When** *(action)*
+  **Then** *(expected outcome)*
+
+- **Given**
+  **When**
   **Then**
+
+---
+
+### Bug Details *(for bug reports only)*
+
+**Reproduction steps:**
+1.
+2.
+3.
+
+**Expected behaviour:**
+
+**Actual behaviour:**
+
+**Environment:**
+- Deployment: Docker / Railway / Local
+- Browser (if UI issue):
+- Role used (Admin / HOD / Teacher / Student):
+
+**Relevant logs or screenshots:**
+
+---
+
+### Additional context
+
+<!-- Any other information, links, or context that helps understand this issue -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -503,6 +503,47 @@ classDiagram
 
 ---
 
+## Environment Configuration
+
+The application reads datasource configuration from environment variables using a two-level fallback chain. Each deployment environment resolves the chain differently.
+
+### Fallback chain (application.properties)
+
+```
+spring.datasource.url
+  → ${DB_URL}                              # Docker Compose always sets this
+  → jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:campusConnect}?...
+                  └─ Railway sets MYSQL_HOST, MYSQL_PORT, MYSQL_DATABASE
+
+spring.datasource.username
+  → ${DB_USERNAME}                         # Docker Compose always sets this
+  → ${MYSQL_USER:campusConnect}            # Railway sets MYSQL_USER
+
+spring.datasource.password
+  → ${DB_PASSWORD}                         # Docker / .env always sets this
+  → ${MYSQL_ROOT_PASSWORD:password}        # Railway MySQL plugin sets this automatically
+```
+
+### Per-environment resolution
+
+| Variable              | Docker Compose        | Railway                                    | Local Dev      |
+|-----------------------|-----------------------|--------------------------------------------|----------------|
+| `DB_URL`              | `jdbc:mysql://db:3306/campusConnect` | not set → MYSQL_* chain used | not set → localhost default |
+| `DB_USERNAME`         | `campusConnect`       | not set → MYSQL_USER                       | not set → `campusConnect` |
+| `DB_PASSWORD`         | from `.env`           | not set → MYSQL_ROOT_PASSWORD              | not set → `password` |
+| `MYSQL_HOST`          | n/a                   | `mysql.railway.internal` (set manually)    | `localhost`    |
+| `MYSQL_PORT`          | n/a                   | `3306` (set manually)                      | `3306`         |
+| `MYSQL_DATABASE`      | n/a                   | `railway` (set by Railway MySQL plugin)    | `campusConnect`|
+| `MYSQL_USER`          | n/a                   | `root` (set manually)                      | `campusConnect`|
+| `MYSQL_ROOT_PASSWORD` | from `.env`           | set by Railway MySQL plugin                | `password`     |
+| `UPLOAD_DIR`          | `/uploads/`           | `/uploads/`                                | `uploads/`     |
+
+### Critical behaviour note
+
+Spring Boot's `${VAR:fallback}` only activates the fallback when `VAR` is **undefined**. An **empty string** is accepted as-is and will produce a broken JDBC URL (e.g., `jdbc:mysql://:3306/railway`). This is the most common source of Railway datasource failures — always verify actual variable values with `railway variables --service <ServiceName>` before deploying.
+
+---
+
 ## Database Migration Strategy
 
 Flyway manages all schema changes. Migrations live in `src/main/resources/db/migration/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,183 @@
+# Contributing to CampusConnect
+
+Thank you for taking the time to contribute. The guidelines below keep the codebase consistent and the review process predictable.
+
+---
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [Branch Strategy](#branch-strategy)
+- [Development Process](#development-process)
+- [Commit Messages](#commit-messages)
+- [Javadoc Requirements](#javadoc-requirements)
+- [Testing Requirements](#testing-requirements)
+- [Pull Request Process](#pull-request-process)
+- [Reporting Issues](#reporting-issues)
+
+---
+
+## Code of Conduct
+
+Be respectful and constructive in all interactions. Treat every contributor as a collaborator, not a critic.
+
+---
+
+## Getting Started
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your fork locally:
+   ```bash
+   git clone https://github.com/<your-username>/CampusConnect.git
+   cd CampusConnect
+   ```
+3. **Set up** the development environment using Docker or the manual setup described in [README.md](README.md).
+4. Verify the test suite is green before making any changes:
+   ```bash
+   mvn test
+   ```
+
+---
+
+## Branch Strategy
+
+| Branch prefix | Purpose | Base branch |
+|---------------|---------|-------------|
+| `main`        | Production — never commit directly | — |
+| `dev`         | Integration — all feature PRs target here | `main` |
+| `feature/*`   | New features | `dev` |
+| `bugfix/*`    | Bug fixes | `dev` |
+| `hotfix/*`    | Critical production fixes | `main` |
+| `docs/*`      | Documentation-only changes | `dev` |
+| `refactor/*`  | Refactoring with no behaviour change | `dev` |
+
+Always branch from `dev` (or `main` for hotfixes only):
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/your-feature-name
+```
+
+---
+
+## Development Process
+
+This project follows **strict Test-Driven Development**:
+
+1. **Red** — Write a failing test that describes the desired behaviour.
+2. **Green** — Write the minimum implementation to make the test pass.
+3. **Commit** — Stage and commit only after all tests are green.
+
+Never commit a feature that does not have a corresponding passing test. The pre-commit hook checks for Javadoc coverage; the CI pipeline blocks merges when tests fail.
+
+```bash
+# Verify all tests pass before every commit
+mvn test
+
+# Run a single test class during development
+mvn test -Dtest=HodControllerTest
+```
+
+---
+
+## Commit Messages
+
+Use the conventional commits format:
+
+```
+<type>: <short summary in imperative mood>
+```
+
+| Type       | When to use |
+|------------|-------------|
+| `feat`     | New feature or capability |
+| `fix`      | Bug fix |
+| `refactor` | Code change with no behaviour change |
+| `test`     | Adding or correcting tests |
+| `docs`     | Documentation only |
+| `config`   | Build, CI, or configuration changes |
+| `chore`    | Dependency updates, tooling |
+
+**Rules:**
+- Summary line is 72 characters maximum
+- Imperative mood: "add user export" not "added user export"
+- No trailing period on the summary line
+- No AI attribution trailers (no "Co-Authored-By: Claude" etc.)
+
+**Examples:**
+```
+feat: add GZIP download for resource files
+fix: prevent HOD from viewing other department courses
+test: cover ownership guard in TeacherController delete endpoint
+docs: update README with Railway deployment instructions
+config: add Flyway migration V3 for announcement timestamps
+```
+
+---
+
+## Javadoc Requirements
+
+Every `public` and `protected` class, interface, method, and field must have a Javadoc comment before a PR can be merged. This is enforced by:
+
+- A `PostToolUse` Claude Code hook that warns after every `.java` edit in development sessions
+- A `pre-commit` git hook that blocks the commit if staged files have undocumented public/protected members
+
+**Rules:**
+- First sentence is the summary — one line only, ends with a period
+- Use `@param`, `@return`, and `@throws` only when they add information beyond what the signature already conveys
+- Do not restate the method name in prose ("Returns the user" for `getUser()` adds nothing)
+
+```java
+/**
+ * Uploads a file to the filesystem and records its metadata in the database.
+ *
+ * @param dto carries the multipart file, course, semester, subject, and category
+ * @throws IOException if the target directory cannot be created or written to
+ */
+public void uploadToFileSystem(FileUploadDTO dto) throws IOException { ... }
+```
+
+---
+
+## Testing Requirements
+
+| Layer | What to test | Framework |
+|-------|-------------|-----------|
+| Controllers | View names, model attributes, redirects, flash messages, role-based access guards | `@WebMvcTest` + Mockito |
+| Services | Business logic, file operations, ownership resolution | JUnit 5 + Mockito |
+| Repositories | Custom JPQL queries and derived finders | `@DataJpaTest` + H2 |
+| Integration | Full application context smoke test | `@SpringBootTest` |
+
+**Test configuration:**
+- Tests use `application-test.properties` which activates H2 in-memory and disables Flyway
+- Never mock the database in `@DataJpaTest` — let H2 handle it; `spring.jpa.hibernate.ddl-auto=create-drop` rebuilds the schema per test run
+- Do not introduce production code changes just to make tests easier to write — redesign the test instead
+
+---
+
+## Pull Request Process
+
+1. Ensure all tests pass locally: `mvn test`
+2. Push your branch: `git push origin feature/your-feature-name`
+3. Open a PR targeting **`dev`** (not `main`), unless this is a hotfix
+4. Fill in the PR template:
+   - **What** changed and **why**
+   - Test plan — what you tested and how
+   - Any screenshots for UI changes
+5. At least one review approval is required before merging
+6. All CI checks (test job) must be green
+7. Squash or rebase as needed to keep history clean before merge
+
+After the feature is stable in `dev`, a separate PR from `dev` → `main` is opened. The `push-image` CI job runs only on `main` merges and deploys to Railway automatically.
+
+---
+
+## Reporting Issues
+
+Use the GitHub issue tracker. Fill in the issue template — it includes a user story format with acceptance criteria. Vague issue reports without reproduction steps will be closed.
+
+Before opening an issue:
+- Search existing issues to avoid duplicates
+- If it is a security vulnerability, do not open a public issue — email the maintainer directly

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
+<a name="readme-top"></a>
+
 [![Contributors][contributors-shield]][contributors-url]
 [![Issues][issues-shield]][issues-url]
 [![GNU License][license-shield]][license-url]
 [![CI][ci-shield]][ci-url]
 [![Docker][docker-shield]][docker-url]
+
+<h1 align="center">CampusConnect</h1>
+<p align="center">A role-based academic management and collaborative learning platform for educational institutions.</p>
 
 <h2>Project Link</h2>
 
@@ -61,10 +66,13 @@
       <ul>
         <li><a href="#option-1-docker-recommended">Option 1: Docker (Recommended)</a></li>
         <li><a href="#option-2-manual-setup">Option 2: Manual Setup</a></li>
+        <li><a href="#option-3-railway-cloud">Option 3: Railway (Cloud)</a></li>
       </ul>
     </li>
+    <li><a href="#environment-variables">Environment Variables</a></li>
+    <li><a href="#development-workflow">Development Workflow</a></li>
     <li><a href="#testing">Testing</a></li>
-    <li><a href="#ci-cd">CI/CD</a></li>
+    <li><a href="#cicd-pipeline">CI/CD Pipeline</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#license">License</a></li>
     <li><a href="#contact">Contact</a></li>
@@ -75,7 +83,9 @@
 
 ## About The Project
 
-**Campus Connect** is a role-based academic management and collaborative learning platform designed for educational institutions. It provides a centralized hub where administrators, department heads, faculty, and students can manage academic workflows, share resources, and collaborate — all within a structured, permission-driven environment.
+**CampusConnect** is a role-based academic management and collaborative learning platform designed for educational institutions. It provides a centralized hub where administrators, department heads, faculty, and students can manage academic workflows, share resources, and collaborate — all within a structured, permission-driven environment.
+
+The platform is built with Spring Boot and Thymeleaf, backed by MySQL, and ships as a multi-stage Docker image deployed to Railway via GitHub Actions.
 
 ---
 
@@ -163,9 +173,9 @@ No manual database setup required. Docker Compose starts MySQL 8.0 and the Sprin
 git clone https://github.com/subodhadhikari2023/CampusConnect.git
 cd CampusConnect
 
-# 2. Create your environment file and fill in your credentials
+# 2. Create your environment file and set credentials
 cp .env.example .env
-# Open .env and set DB_PASSWORD and MYSQL_ROOT_PASSWORD
+# Edit .env and set DB_PASSWORD and MYSQL_ROOT_PASSWORD
 
 # 3. Build and start both containers (app + MySQL)
 docker compose up --build
@@ -174,13 +184,13 @@ docker compose up --build
 The application will be available at `http://localhost:8080`.
 
 **What Docker sets up automatically:**
-- MySQL 8.0 container — creates the `campusConnect` database from your `.env`
-- Spring Boot app — compiled via multi-stage build, waits for MySQL health check before starting
+- MySQL 8.0 container with the `campusConnect` database
+- Spring Boot app compiled via multi-stage build, waits for MySQL health check before starting
 - Flyway runs `V1__init_schema.sql` then `V2__seed_data.sql` on first boot — no manual SQL step needed
 - `/actuator/health` is the Docker health check endpoint
 
 ```bash
-# Stop the containers
+# Stop containers
 docker compose down
 
 # Stop and delete all data (fresh start)
@@ -191,8 +201,6 @@ docker compose down -v
 
 ### Option 2: Manual Setup (No Docker)
 
-Use this if you prefer to run the application directly on your machine without containers.
-
 **Prerequisites**
 
 - Java Development Kit 17
@@ -202,24 +210,187 @@ Use this if you prefer to run the application directly on your machine without c
 
 **Steps**
 
-`setup.sh` automates the entire manual setup — checking dependencies, creating the `.env`, initialising the database, and starting the application.
+`setup.sh` automates the entire manual setup — checking dependencies, creating `.env`, initialising the database, and starting the application.
 
 ```bash
 # 1. Clone the repository
 git clone https://github.com/subodhadhikari2023/CampusConnect.git
 cd CampusConnect
 
-# 2. Run the setup script (handles everything below automatically)
+# 2. Run the setup script (handles everything automatically)
 chmod +x setup.sh && ./setup.sh
 ```
 
 On first run, `setup.sh` will:
 1. Verify Java 17+, Maven, and MySQL client are installed
-2. Create `Project/.env` if it does not exist, then exit — fill in `DB_PASSWORD` and re-run
+2. Create `.env` if it does not exist, then exit — fill in `DB_PASSWORD` and re-run
 3. Check whether the database exists — if not, prompt for MySQL root password and run the schema script
 4. Start the application via `./mvnw spring-boot:run`
 
 The application will be available at `http://localhost:8080`.
+
+**Dummy credentials** (all use password `password`):
+
+| Username | Role    |
+|----------|---------|
+| admin1   | Admin   |
+| admin2   | Admin   |
+| hod1     | HOD     |
+| hod2     | HOD     |
+| teacher1 | Teacher |
+| teacher2 | Teacher |
+| student1 | Student |
+| student2 | Student |
+
+---
+
+### Option 3: Railway (Cloud)
+
+The application is continuously deployed to Railway from the `main` branch. No local setup is needed to view the live version.
+
+**How Railway deployment works:**
+
+1. A push to `main` triggers the GitHub Actions CI pipeline.
+2. CI runs all tests, then builds and pushes a Docker image to GHCR tagged `:latest` and `:<sha>`.
+3. Railway is configured to watch GHCR for new images and redeploys automatically.
+4. On startup, Flyway applies any pending migrations against the Railway-hosted MySQL instance.
+
+**To deploy your own fork to Railway:**
+
+1. Fork the repository and create a Railway project.
+2. Add a **MySQL** plugin to your Railway project — Railway provides `MYSQLHOST`, `MYSQLPORT`, `MYSQLDATABASE`, `MYSQLUSER`, and `MYSQL_ROOT_PASSWORD` automatically.
+3. In your CampusConnect Railway service, set these variables explicitly (the app reads them from the environment):
+
+   | Variable           | Value                   |
+   |--------------------|-------------------------|
+   | `MYSQL_HOST`       | `mysql.railway.internal`|
+   | `MYSQL_PORT`       | `3306`                  |
+   | `MYSQL_USER`       | `root`                  |
+   | `UPLOAD_DIR`       | `/uploads/`             |
+   | `SERVER_PORT`      | `8080`                  |
+
+   `MYSQL_ROOT_PASSWORD` and `MYSQL_DATABASE` are injected automatically by the Railway MySQL plugin.
+
+4. Connect your GitHub repository to the Railway service and enable **GitHub Actions → GHCR** deployment (see CI/CD section below).
+
+---
+
+## Environment Variables
+
+The application reads configuration from environment variables with a layered fallback chain. Each environment resolves differently:
+
+| Variable              | Docker Compose        | Railway (auto)                    | Local Dev (default)    |
+|-----------------------|-----------------------|-----------------------------------|------------------------|
+| `DB_URL`              | `jdbc:mysql://db:3306/campusConnect` | *(not set — Railway path used)* | *(not set — localhost fallback)* |
+| `DB_USERNAME`         | `campusConnect`       | *(falls through to `MYSQL_USER`)* | `campusConnect`        |
+| `DB_PASSWORD`         | set via `.env`        | *(falls through to `MYSQL_ROOT_PASSWORD`)* | `password`  |
+| `MYSQL_HOST`          | *(not needed)*        | `mysql.railway.internal`          | `localhost`            |
+| `MYSQL_PORT`          | *(not needed)*        | `3306`                            | `3306`                 |
+| `MYSQL_DATABASE`      | *(not needed)*        | `railway` *(set by plugin)*       | `campusConnect`        |
+| `MYSQL_USER`          | *(not needed)*        | `root`                            | `campusConnect`        |
+| `MYSQL_ROOT_PASSWORD` | set via `.env`        | set by Railway MySQL plugin       | `password`             |
+| `UPLOAD_DIR`          | `/uploads/`           | `/uploads/`                       | `uploads/`             |
+
+**Fallback chain in `application.properties`:**
+
+```
+DB_URL           → MYSQL_HOST:MYSQL_PORT/MYSQL_DATABASE → localhost:3306/campusConnect
+DB_USERNAME      → MYSQL_USER → campusConnect
+DB_PASSWORD      → MYSQL_ROOT_PASSWORD → password
+```
+
+`DB_URL`, `DB_USERNAME`, and `DB_PASSWORD` take highest priority and are always set by Docker Compose. When they are absent (Railway and local dev), the app falls back to the Railway-native `MYSQL_*` variables, and finally to hardcoded localhost defaults for local development.
+
+**Important:** Spring Boot's `${VAR:fallback}` syntax only activates the fallback when the variable is **undefined**. An empty string is accepted as-is and will cause a broken connection URL. Always verify actual variable values with `railway variables --service <name>` rather than assuming the Railway dashboard shows the effective value.
+
+Copy `.env.example` to `.env` for Docker or local use:
+
+```bash
+cp .env.example .env
+```
+
+`.env` is git-ignored and must never be committed.
+
+---
+
+## Development Workflow
+
+All feature work follows a **branch → PR → review → merge** cycle. Direct commits to `main` are not permitted.
+
+```
+main        ──────────────────────────────────────────► production
+               ▲                   ▲
+               │ PR merge          │ PR merge
+dev         ───┼────────────────────┼──────────────────►
+               │                   │
+feature/*   ───┘                   │
+                                   │
+bugfix/*    ───────────────────────┘
+```
+
+### Branch Strategy
+
+| Branch prefix | Purpose |
+|---------------|---------|
+| `main`        | Production-ready code; every commit triggers Railway deploy |
+| `dev`         | Integration branch; all feature PRs target `dev` first |
+| `feature/*`   | New features — branch from `dev`, PR back to `dev` |
+| `bugfix/*`    | Bug fixes — branch from `dev` (or `main` for hotfixes) |
+
+### Step-by-step
+
+```bash
+# 1. Start from an up-to-date dev branch
+git checkout dev && git pull origin dev
+
+# 2. Create a feature branch
+git checkout -b feature/your-feature-name
+
+# 3. Develop with TDD — write tests first, then implementation
+mvn test   # must be green before committing
+
+# 4. Commit with a descriptive message
+git add <files>
+git commit -m "feat: describe what this adds and why"
+
+# 5. Push and open a PR targeting dev
+git push origin feature/your-feature-name
+# Open PR: feature/your-feature-name → dev
+
+# 6. After review and merge into dev, open a PR: dev → main
+# CI runs automatically; Railway deploys on merge to main
+```
+
+### CI/CD Pipeline
+
+Every push and pull request triggers GitHub Actions:
+
+```
+Push to any branch
+        │
+        ▼
+  ┌─────────────┐
+  │  test job   │  mvn test (194 tests, H2 in-memory)
+  └──────┬──────┘
+         │ pass
+         ▼
+  Is branch == main?
+         │
+    Yes  │
+         ▼
+  ┌──────────────────┐
+  │  push-image job  │  docker build → push to GHCR
+  │                  │  tags: :latest + :<sha>
+  └──────┬───────────┘
+         │
+         ▼
+  Railway watches GHCR
+  → auto-redeploys
+  → Flyway applies migrations
+  → /actuator/health confirms startup
+```
+
+The test job runs on **all branches and all pull requests**. The image-push job runs **only on merges to `main`**.
 
 ---
 
@@ -242,17 +413,32 @@ mvn test
 
 # Run a specific test class
 mvn test -Dtest=HodControllerTest
+
+# Run tests matching a pattern
+mvn test -Dtest="*ControllerTest"
 ```
 
 ---
 
-## CI/CD
+## CI/CD Pipeline
 
-Every push and pull request targeting `main` triggers the GitHub Actions pipeline:
+The GitHub Actions workflow file is at `.github/workflows/ci.yml`.
 
-1. **Test job** — Runs the full 194-test suite against H2 in-memory DB (no MySQL required)
-2. **Push job** *(main branch only)* — Builds the Docker image and pushes to GitHub Container Registry (GHCR) tagged with `:latest` and the commit SHA
-3. **Railway** — Automatically redeploys on every push to `main`; Flyway applies any new migrations on startup
+### Jobs
+
+**`test` — Build & Test**
+- Triggers: every push to any branch; every pull request targeting `main`
+- Environment: `ubuntu-latest`, Java 17 Temurin, Maven cache enabled
+- Runs: `mvn test` with `SPRING_PROFILES_ACTIVE=test` (H2 in-memory, Flyway disabled)
+- No MySQL service required — all 194 tests run against H2
+
+**`push-image` — Docker Build & Push to GHCR**
+- Triggers: push to `main` only, after `test` passes
+- Logs in to `ghcr.io` using `GITHUB_TOKEN` (no secret configuration needed)
+- Builds the multi-stage Dockerfile: Maven build stage → JRE 17 Alpine runtime
+- Pushes two tags:
+  - `ghcr.io/subodhadhikari2023/campusconnect:latest`
+  - `ghcr.io/subodhadhikari2023/campusconnect:<commit-sha>`
 
 Pull the latest image:
 
@@ -260,17 +446,29 @@ Pull the latest image:
 docker pull ghcr.io/subodhadhikari2023/campusconnect:latest
 ```
 
+### Railway Auto-Deploy
+
+Railway is connected to the GHCR repository. When a new `:latest` image is pushed, Railway:
+
+1. Pulls the new image
+2. Starts the container with environment variables injected
+3. Spring Boot starts → Flyway checks `flyway_schema_history` → applies any new `V{n}` migrations
+4. `/actuator/health` is polled; traffic is routed only after the health check passes
+
 ---
 
 ## Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide, including branch naming, TDD requirements, Javadoc rules, and commit message conventions.
+
+**Quick reference:**
+
 1. Fork the repository
-2. Clone your fork: `git clone https://github.com/your_username/CampusConnect.git`
-3. Create a feature branch: `git checkout -b feature/your-feature-name`
-4. Make your changes and stage them: `git add <files>`
-5. Commit: `git commit -m 'Add your feature description'`
-6. Push: `git push origin feature/your-feature-name`
-7. Open a Pull Request against `main`
+2. Branch from `dev`: `git checkout -b feature/your-feature-name`
+3. Write tests first, then implementation (TDD — red → green → commit)
+4. Add Javadoc to all `public` and `protected` members
+5. Commit: `git commit -m 'feat: describe the change'`
+6. Push and open a PR targeting `dev`
 
 Contributions are welcome. Please open an issue first for significant changes.
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -72,7 +72,7 @@ Displays the department name, total faculty, total students, and total courses.
 
 ### Courses
 
-**Add a course:** `/admin/add-course` → enter a course name → Save. You are redirected to the semester setup page for the new course.
+**Add a course:** `/hod/add-course` → enter a course name → Save. You are redirected to the semester setup page for the new course.
 
 **Manage courses:** `/hod/manage-course` lists courses. Use **Edit** to rename or **Delete** to remove (deletion blocked if the course has semesters).
 


### PR DESCRIPTION
## Summary

- **README** — added project title and `readme-top` anchor (broken link fix), Railway deployment instructions (Option 3 with per-variable table), Environment Variables section documenting the full `DB_*` → `MYSQL_*` → localhost fallback chain and the Spring placeholder empty-string caveat, Development Workflow section with branch diagram and CI/CD pipeline flow, and expanded CI/CD section with job-by-job detail
- **ARCHITECTURE** — new Environment Configuration section with per-environment variable resolution table and the critical `${VAR:fallback}` empty-string vs undefined behaviour note
- **CONTRIBUTING** — new file: branch strategy, TDD requirement (red → green → commit), commit message conventions with type table, Javadoc rules with code example, per-layer testing requirements, and full PR process
- **USER_MANUAL** — fixed URL typo `/admin/add-course` → `/hod/add-course` in HOD Courses section
- **ISSUE_TEMPLATE** — replaced empty placeholder with a proper bug/feature template including Given/When/Then acceptance criteria and reproduction steps

## Test plan

- [x] Verify all Mermaid diagrams render correctly on GitHub
- [x] Verify badge links resolve (contributors, issues, license, CI, Docker)
- [x] Confirm "back to top" link works in README (anchors to `readme-top`)
- [x] Confirm CONTRIBUTING.md renders without formatting errors
- [x] Confirm no broken internal links (`CONTRIBUTING.md`, `LICENSE`, `docs/USER_MANUAL.md`)